### PR TITLE
feat: common-module 공통 응답/예외처리 

### DIFF
--- a/common-module/build.gradle
+++ b/common-module/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
     // AOP 지원 (@Aspect, etc.)
     implementation 'org.springframework.boot:spring-boot-starter-aop'

--- a/common-module/src/main/java/com/monkey/commonmodule/dto/ResDTO.java
+++ b/common-module/src/main/java/com/monkey/commonmodule/dto/ResDTO.java
@@ -13,4 +13,22 @@ public class ResDTO<T> {
     private String code;
     private String message;
     private T data;
+
+    // 성공 시 응답
+    public static <T> ResDTO<T> success(T data) {
+        return ResDTO.<T>builder()
+                .code(ResponseCode.SUCCESS.getCode())
+                .message(ResponseCode.SUCCESS.getMessage())
+                .data(data)
+                .build();
+    }
+
+    // 실패 시 응답
+    public static <T> ResDTO<T> fail(ResponseCode code) {
+        return ResDTO.<T>builder()
+                .code(code.getCode())
+                .message(code.getMessage())
+                .data(null)
+                .build();
+    }
 }

--- a/common-module/src/main/java/com/monkey/commonmodule/dto/ResponseCode.java
+++ b/common-module/src/main/java/com/monkey/commonmodule/dto/ResponseCode.java
@@ -1,47 +1,52 @@
 package com.monkey.commonmodule.dto;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ResponseCode {
 
     // 공통
-    SUCCESS("000", "성공적으로 처리됐습니다."),
-    NEED_LOGIN("001", "로그인이 필요합니다."),
-    FORBIDDEN("002", "권한이 없습니다."),
-    DUPLICATED_REQUEST("003", "중복된 요청입니다."),
-    NOT_FOUND("004", "존재하지 않는 데이터입니다."),
+    SUCCESS("000", "성공적으로 처리됐습니다.", HttpStatus.OK),
+    NEED_LOGIN("001", "로그인이 필요합니다.", HttpStatus.UNAUTHORIZED),
+    FORBIDDEN("002", "권한이 없습니다.", HttpStatus.FORBIDDEN),
+    DUPLICATED_REQUEST("003", "중복된 요청입니다.", HttpStatus.CONFLICT),
+    NOT_FOUND("004", "존재하지 않는 데이터입니다.", HttpStatus.NOT_FOUND),
 
     // User
-    USER_ALREADY_EXISTS("US100", "이미 등록된 회원입니다."),
-    USER_NOT_FOUND("US200", "존재하지 않는 회원입니다."),
-    PASSWORD_MISMATCH("US201", "비밀번호가 일치하지 않습니다."),
+    USER_ALREADY_EXISTS("US100", "이미 등록된 회원입니다.", HttpStatus.CONFLICT),
+    USER_NOT_FOUND("US200", "존재하지 않는 회원입니다.", HttpStatus.NOT_FOUND),
+    PASSWORD_MISMATCH("US201", "비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // Store
-    STORE_ALREADY_EXISTS("S100", "이미 등록된 스토어입니다."),
-    STORE_TIME_DUPLICATE("S101", "이미 등록된 시간대입니다."),
+    STORE_ALREADY_EXISTS("S100", "이미 등록된 스토어입니다.", HttpStatus.CONFLICT),
+    STORE_TIME_DUPLICATE("S101", "이미 등록된 시간대입니다.", HttpStatus.CONFLICT),
 
     // Store-Reservation
-    STORE_RESERVATION_FULL("SR100", "예약이 마감되었습니다."),
-    OUT_OF_RESERVATION_TIME("SR101", "예약 가능한 시간에서 벗어났습니다."),
+    STORE_RESERVATION_FULL("SR100", "예약이 마감되었습니다.", HttpStatus.BAD_REQUEST),
+    OUT_OF_RESERVATION_TIME("SR101", "예약 가능한 시간에서 벗어났습니다.", HttpStatus.BAD_REQUEST),
 
     // Product
-    PRODUCT_ALREADY_EXISTS("P100", "이미 등록된 상품입니다."),
+    PRODUCT_ALREADY_EXISTS("P100", "이미 등록된 상품입니다.", HttpStatus.CONFLICT),
 
     // Product-Reservation
-    PRODUCT_RESERVATION_FULL("PR100", "예약이 마감되었습니다."),
-    NOT_STORE_MEMBER("PR101", "스토어 예약 회원이 아닙니다."),
+    PRODUCT_RESERVATION_FULL("PR100", "예약이 마감되었습니다.", HttpStatus.BAD_REQUEST),
+    NOT_STORE_MEMBER("PR101", "스토어 예약 회원이 아닙니다.", HttpStatus.FORBIDDEN),
 
     // Slack
-    SLACK_SEND_FAILED("SL100", "전송이 실패되었습니다.");
+    SLACK_SEND_FAILED("SL100", "전송이 실패되었습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
+    // 예상치 못한 예외 발생
+    INTERNAL_SERVER_ERROR("999", "서버 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String code;
     private final String message;
+    private final HttpStatus status;
 
-    ResponseCode(String code, String message) {
+    ResponseCode(String code, String message, HttpStatus status) {
         this.code = code;
         this.message = message;
+        this.status = status;
     }
 }
 

--- a/common-module/src/main/java/com/monkey/commonmodule/dto/ResponseCode.java
+++ b/common-module/src/main/java/com/monkey/commonmodule/dto/ResponseCode.java
@@ -1,0 +1,47 @@
+package com.monkey.commonmodule.dto;
+
+import lombok.Getter;
+
+@Getter
+public enum ResponseCode {
+
+    // 공통
+    SUCCESS("000", "성공적으로 처리됐습니다."),
+    NEED_LOGIN("001", "로그인이 필요합니다."),
+    FORBIDDEN("002", "권한이 없습니다."),
+    DUPLICATED_REQUEST("003", "중복된 요청입니다."),
+    NOT_FOUND("004", "존재하지 않는 데이터입니다."),
+
+    // User
+    USER_ALREADY_EXISTS("US100", "이미 등록된 회원입니다."),
+    USER_NOT_FOUND("US200", "존재하지 않는 회원입니다."),
+    PASSWORD_MISMATCH("US201", "비밀번호가 일치하지 않습니다."),
+
+    // Store
+    STORE_ALREADY_EXISTS("S100", "이미 등록된 스토어입니다."),
+    STORE_TIME_DUPLICATE("S101", "이미 등록된 시간대입니다."),
+
+    // Store-Reservation
+    STORE_RESERVATION_FULL("SR100", "예약이 마감되었습니다."),
+    OUT_OF_RESERVATION_TIME("SR101", "예약 가능한 시간에서 벗어났습니다."),
+
+    // Product
+    PRODUCT_ALREADY_EXISTS("P100", "이미 등록된 상품입니다."),
+
+    // Product-Reservation
+    PRODUCT_RESERVATION_FULL("PR100", "예약이 마감되었습니다."),
+    NOT_STORE_MEMBER("PR101", "스토어 예약 회원이 아닙니다."),
+
+    // Slack
+    SLACK_SEND_FAILED("SL100", "전송이 실패되었습니다.");
+
+
+    private final String code;
+    private final String message;
+
+    ResponseCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}
+

--- a/common-module/src/main/java/com/monkey/commonmodule/exception/CustomException.java
+++ b/common-module/src/main/java/com/monkey/commonmodule/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.monkey.commonmodule.exception;
+
+import com.monkey.commonmodule.dto.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ResponseCode responseCode;
+
+    public CustomException(ResponseCode responseCode) {
+        super(responseCode.getMessage());
+        this.responseCode = responseCode;
+    }
+}

--- a/common-module/src/main/java/com/monkey/commonmodule/exception/handler/CommonExceptionHandler.java
+++ b/common-module/src/main/java/com/monkey/commonmodule/exception/handler/CommonExceptionHandler.java
@@ -24,8 +24,7 @@ public class CommonExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ResDTO<Object>> handleUnhandledException(Exception e) {
         log.error("예상치 못한 에러 발생", e);
-        return ResponseEntity.ok(
-                ResDTO.fail(ResponseCode.INTERNAL_SERVER_ERROR)
-        );
+        return ResponseEntity.status(ResponseCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ResDTO.fail(ResponseCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/common-module/src/main/java/com/monkey/commonmodule/exception/handler/CommonExceptionHandler.java
+++ b/common-module/src/main/java/com/monkey/commonmodule/exception/handler/CommonExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.monkey.commonmodule.exception.handler;
+
+import com.monkey.commonmodule.dto.ResDTO;
+import com.monkey.commonmodule.dto.ResponseCode;
+import com.monkey.commonmodule.exception.CustomException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class CommonExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ResDTO<Object>> handleCustomException(CustomException e) {
+        ResponseCode code = e.getResponseCode();
+
+        return ResponseEntity.status(code.getStatus())
+                .body(ResDTO.fail(code));
+    }
+
+    // 예상치 못한 예외 발생 시
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ResDTO<Object>> handleUnhandledException(Exception e) {
+        log.error("예상치 못한 에러 발생", e);
+        return ResponseEntity.ok(
+                ResDTO.fail(ResponseCode.INTERNAL_SERVER_ERROR)
+        );
+    }
+}


### PR DESCRIPTION
### **📌 작업 내용**

* 팀끼리 정한 응답코드를 클라이언트에 반환


### **🧑‍💻 작업 유형**

- [X]  새로운 기능 추가

### **💻 사용 예시**

* 컨트롤러에서 성공 처리:
<img width="678" alt="스크린샷 2025-04-08 오후 3 59 00" src="https://github.com/user-attachments/assets/4404e616-798e-4107-9606-19404b70c9df" />

* 서비스에서 예외처리:
<img width="698" alt="스크린샷 2025-04-08 오후 4 25 44" src="https://github.com/user-attachments/assets/8d9c0543-39ea-4c39-b380-add6b8230659" />
