### PR TITLE
feat: 회원 전체 조회, 상제 조회 DTO, Contorller 구현

### DIFF
--- a/user-service/http/User.http
+++ b/user-service/http/User.http
@@ -1,0 +1,9 @@
+### GET USER
+GET http://localhost:8081/v1/users
+Content-Type: application/json
+
+
+### GET USER Details
+GET http://localhost:8081/v1/users/1
+Content-Type: application/json
+

--- a/user-service/src/main/java/com/monkey/userservice/application/dto/response/ResUserGetByIdDTOApiV1.java
+++ b/user-service/src/main/java/com/monkey/userservice/application/dto/response/ResUserGetByIdDTOApiV1.java
@@ -1,0 +1,39 @@
+package com.monkey.userservice.application.dto.response;
+
+import com.monkey.userservice.domain.entity.UserEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ResUserGetByIdDTOApiV1 {
+
+    private User user;
+
+    //userEntity -> dto
+    public static ResUserGetByIdDTOApiV1 of(UserEntity userEntity) {
+        return ResUserGetByIdDTOApiV1.builder()
+                .user(User.from(userEntity))
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class User {
+
+        private Long userId;
+        private String username;
+        private String slackId;
+        private UserEntity.Role role;
+
+        //User -> Dto
+        public static User from(UserEntity userEntity) {
+            return User.builder()
+                    .userId(userEntity.getUserId())
+                    .username(userEntity.getUsername())
+                    .slackId(userEntity.getSlackId())
+                    .role(userEntity.getRole())
+                    .build();
+        }
+    }
+}

--- a/user-service/src/main/java/com/monkey/userservice/application/dto/response/ResUserGetDTOApiV1.java
+++ b/user-service/src/main/java/com/monkey/userservice/application/dto/response/ResUserGetDTOApiV1.java
@@ -1,0 +1,47 @@
+package com.monkey.userservice.application.dto.response;
+
+import com.monkey.userservice.domain.entity.UserEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class ResUserGetDTOApiV1 {
+
+    private List<User> userList;
+
+    public static ResUserGetDTOApiV1 of(List<UserEntity> userEntityList) {
+        return ResUserGetDTOApiV1.builder()
+                .userList(User.from(userEntityList))
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class User {
+
+        private Long userId;
+        private String username;
+        private String slackId;
+        private UserEntity.Role role;
+
+        public static User from(UserEntity userEntity) {
+            return User.builder()
+                    .userId(userEntity.getUserId())
+                    .username(userEntity.getUsername())
+                    .slackId(userEntity.getSlackId())
+                    .role(userEntity.getRole())
+                    .build();
+        }
+
+        public static List<User> from(List<UserEntity> userEntityList) {
+            return userEntityList
+                    .stream()
+                    .map(userEntity -> User.from(userEntity))
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/user-service/src/main/java/com/monkey/userservice/presentation/controller/UserControllerApiV1.java
+++ b/user-service/src/main/java/com/monkey/userservice/presentation/controller/UserControllerApiV1.java
@@ -1,0 +1,67 @@
+package com.monkey.userservice.presentation.controller;
+
+import com.monkey.commonmodule.dto.ResDTO;
+import com.monkey.userservice.application.dto.response.ResUserGetByIdDTOApiV1;
+import com.monkey.userservice.application.dto.response.ResUserGetDTOApiV1;
+import com.monkey.userservice.domain.entity.UserEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/users")
+@RequiredArgsConstructor
+public class UserControllerApiV1 {
+
+    //사용자 전체 조회
+    @GetMapping
+    public ResponseEntity<ResDTO<ResUserGetDTOApiV1>> getBy(
+            //@RequestParam(required = false) String searchValue,
+            //@PageableDefault(sort="id", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+
+        List<UserEntity> userList = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            userList.add(UserEntity.builder()
+                    .userId((long) i)
+                    .username("testUser"+ i)
+                    .slackId("slackID" + i)
+                    .role(UserEntity.Role.USER)
+                    .build()
+            );
+        }
+
+        ResUserGetDTOApiV1 response = ResUserGetDTOApiV1.of(userList);
+
+        return new ResponseEntity<>(
+                ResDTO.success(response),
+                HttpStatus.OK
+        );
+    }
+
+    //사용자 정보 조회
+    @GetMapping("/{userId}")
+    public ResponseEntity<ResDTO<ResUserGetByIdDTOApiV1>> getBy(@PathVariable(name="userId") Long userId) {
+
+        UserEntity user = UserEntity.builder()
+                .userId(userId)
+                .username("testUser")
+                .slackId("slackId1")
+                .role(UserEntity.Role.USER)
+                .build();
+
+        ResUserGetByIdDTOApiV1 resDto = ResUserGetByIdDTOApiV1.of(user);
+
+        return new ResponseEntity<>(
+                ResDTO.success(resDto),
+                HttpStatus.OK
+        );
+    }
+}


### PR DESCRIPTION
### **📌 작업 내용**

회원 전체 정보를 조회(마스터)와 회원 정보를 선택하여 상세하게 조회할 수 있는 기능

- As-is
    - (변경 전 설명을 여기에 작성)
- To-be
    - controller에 getBy메소드를 만들어서 진행
    - 상세 조회 시, userId를 적용하여 선택 회원 정보만 출력되도록 진행
    - DTO : ResUserGetByIdDTOApiV1, ResUserGetDTOApiV1

### **🧑‍💻 작업 유형**

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  코드 리팩토링
- [ ]  문서 수정
- [ ]  설정 변경
- [ ]  CI/CD 변경

### **📷 관련 이미지**

해당 Pull Request와 관련된 이미지가 있을 경우 여기에 첨부해주세요.

### **🚨 주의 사항**

- 추후에 전제 조회 리스트는 Page를 적용할 예정입니다. 참고 부탁드립니다.

### **🤔 토론**

기능을 추가하면서 생긴 고민을 작성해주세요.
