### PR TITLE
feat: 팝업스토어 예약 단건 상세조회 구현

### DIFF
--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationGetByIdDTOApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationGetByIdDTOApiV1.java
@@ -1,0 +1,82 @@
+package com.monkey.storereservationservice.application.dto.response;
+
+import com.monkey.storereservationservice.domain.StoreReservation.entity.StoreReservationStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class ResStoreReservationGetByIdDTOApiV1 {
+
+    private StoreReservation storeReservation;
+
+    public static ResStoreReservationGetByIdDTOApiV1 of() {
+        return ResStoreReservationGetByIdDTOApiV1.builder()
+                .storeReservation(StoreReservation.from())
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class StoreReservation {
+        private UUID storeReservationId;
+        private StoreReservationStatus status;
+        private TimeSlot timeSlot;
+        private User user;
+
+        public static StoreReservation from() {
+            return StoreReservation.builder()
+                    .storeReservationId(UUID.randomUUID())
+                    .status(StoreReservationStatus.SCHEDULED)
+                    .timeSlot(TimeSlot.from())
+                    .user(User.from())
+                    .build();
+        }
+
+        @Getter
+        @Builder
+        public static class TimeSlot {
+            private Store store;
+            private LocalDate date;
+            private LocalTime entryTime;
+            private LocalTime exitTime;
+
+            public static TimeSlot from() {
+                return TimeSlot.builder()
+                        .store(Store.from())
+                        .date(LocalDate.parse("2025-04-19"))
+                        .entryTime(LocalTime.parse("10:00"))
+                        .exitTime(LocalTime.parse("11:00"))
+                        .build();
+            }
+
+            @Getter
+            @Builder
+            public static class Store {
+                private UUID storeId;
+
+                public static Store from() {
+                    return Store.builder()
+                            .storeId(UUID.randomUUID())
+                            .build();
+                }
+            }
+        }
+
+        @Getter
+        @Builder
+        public static class User {
+            private Long userId;
+
+            public static User from() {
+                return User.builder()
+                        .userId(1L)
+                        .build();
+            }
+        }
+    }
+}

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationGetDTOApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationGetDTOApiV1.java
@@ -4,6 +4,8 @@ import com.monkey.storereservationservice.domain.StoreReservation.entity.StoreRe
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -50,16 +52,16 @@ public class ResStoreReservationGetDTOApiV1 {
         @Builder
         public static class TimeSlot {
             private Store store;
-            private String date;
-            private String startTime;
-            private String endTime;
+            private LocalDate date;
+            private LocalTime entryTime;
+            private LocalTime exitTime;
 
             public static TimeSlot from() {
                 return TimeSlot.builder()
                         .store(Store.from())
-                        .date("0")
-                        .startTime("0")
-                        .endTime("0")
+                        .date(LocalDate.parse("2025-04-19"))
+                        .entryTime(LocalTime.parse("10:00"))
+                        .exitTime(LocalTime.parse("11:00"))
                         .build();
             }
 

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationGetDTOApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationGetDTOApiV1.java
@@ -41,7 +41,6 @@ public class ResStoreReservationGetDTOApiV1 {
         }
 
         public static List<StoreReservation> from(List<UUID> tmpList) {
-//            List<UUID> tmpList = List.of(UUID.randomUUID(), UUID.randomUUID());
 
             return tmpList.stream()
                     .map(id -> StoreReservation.from())

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1.java
@@ -2,6 +2,7 @@ package com.monkey.storereservationservice.presentation.controller;
 
 import com.monkey.commonmodule.dto.ResDTO;
 import com.monkey.storereservationservice.application.dto.request.ReqStoreReservationPostDTOApiV1;
+import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetByIdDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPostByIdCancelDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPostDTOApiV1;
@@ -46,6 +47,18 @@ public class StoreReservationControllerApiV1 {
             @RequestParam(required = false) UUID storeId
     ) {
         ResStoreReservationGetDTOApiV1 resDto = ResStoreReservationGetDTOApiV1.of();
+
+        return new ResponseEntity<>(
+                ResDTO.success(resDto),
+                HttpStatus.OK
+        );
+    }
+
+    @GetMapping("/{storeReservationId}")
+    public ResponseEntity<ResDTO<ResStoreReservationGetByIdDTOApiV1>> getDetailBy(
+            @PathVariable UUID storeReservationId
+    ) {
+        ResStoreReservationGetByIdDTOApiV1 resDto = ResStoreReservationGetByIdDTOApiV1.of();
 
         return new ResponseEntity<>(
                 ResDTO.success(resDto),

--- a/store-reservation-service/src/test/resources/test/StoreReservationTest.http
+++ b/store-reservation-service/src/test/resources/test/StoreReservationTest.http
@@ -1,0 +1,22 @@
+### 예약 생성 테스트
+POST http://localhost:8083/v1/store-reservations
+Content-Type: application/json
+
+{
+  "storeReservation" : {
+    "timeSlotId": "123e4567-e89b-12d3-a456-426614174000",
+    "personCount": 1
+  }
+}
+
+### 예약 취소 테스트
+POST http://localhost:8083/v1/store-reservations/123e4567-e89b-12d3-a456-426614174000/cancel
+Content-Type: application/json
+
+### 예약 전체 목록 조회 테스트
+GET http://localhost:8083/v1/store-reservations
+Content-Type: application/json
+
+### 예약 단건 상세 조회 테스트
+GET http://localhost:8083/v1/store-reservations/123e4567-e89b-12d3-a456-426614174000
+Content-Type: application/json


### PR DESCRIPTION
### **📌 작업 내용**

- As-is
    - timeSlot 의 날짜, 시간을 String 처리
- To-be
    - timeSlot 의 날짜, 시간을 LocalDate, LocalTime 으로 변경
    - 변수명 entryTime 과 exitTime 으로 변경
<br>

- As-is
    - 예약 내역 목록만 조회 가능했었습니다.
- To-be
    - 예약 내역을 **상세 조회**하는 기능을 구현하였습니다.
    - 팝업스토어 예약 도메인의 **테스트 코드**를 작성하였습니다.
<br>

### **🧑‍💻 작업 유형**

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  코드 리팩토링
- [X]  문서 수정
- [ ]  설정 변경
- [ ]  CI/CD 변경
