### PR TITLE
refactor : 각 서브 모듈 gradle에 적용한 Swagger 설정 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.4' apply false
     id 'io.spring.dependency-management' version '1.1.7' apply false
-    id 'com.epages.restdocs-api-spec' version '0.18.4'
 }
 
 java {
@@ -52,16 +51,4 @@ subprojects {
     tasks.named('test') {
         useJUnitPlatform()
     }
-
-    openapi3 {
-        servers = [
-                { url = 'http://localhost' },
-                { url = 'http://production-api-server-url.com' }
-        ]
-        title = 'Popup Store API'
-        description = 'Popup Store API description'
-        version = '1.0.0'
-        format = 'json'
-    }
-
 }

--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -1,9 +1,3 @@
-plugins {
-    id 'java'
-    id 'org.springframework.boot'
-    id 'io.spring.dependency-management'
-}
-
 ext {
     set('springCloudVersion', "2024.0.1")
 }

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -9,101 +9,41 @@ spring:
   cloud:
     gateway:
       routes:
-        # User-service
+        # User
         - id: user-service
           uri: lb://user-service
           predicates:
-            - Path=/v1/users/**
-          filters:
-            - RewritePath=/v1/users/(?<segment>.*), /${segment}
-
-        # User-service Swagger Docs
-        - id: user-service-swagger
-          uri: lb://user-service
-          predicates:
-            - Path=/user-service/v3/api-docs
-          filters:
-            - RewritePath=/user-service/v3/api-docs, /v3/api-docs
+            - Path=/v1/users/**, /springdoc/openapi3-user-service.json
 
         # Store-service
         - id: store-service
           uri: lb://store-service
           predicates:
-            - Path=/v1/stores/**
-          filters:
-            - RewritePath=/v1/stores/(?<segment>.*), /${segment}
-
-        # Store-service Swagger Docs
-        - id: store-service-swagger
-          uri: lb://store-service
-          predicates:
-            - Path=/store-service/v3/api-docs
-          filters:
-            - RewritePath=/store-service/v3/api-docs, /v3/api-docs
+            - Path=/v1/stores/**, /springdoc/openapi3-store-service.json
 
         # Store-reservation-service
         - id: store-reservation-service
           uri: lb://store-reservation-service
           predicates:
-            - Path=/v1/store-reservations/**
-          filters:
-            - RewritePath=/v1/store-reservations/(?<segment>.*), /${segment}
+            - Path=/v1/store-reservations/**, /springdoc/openapi3-store-reservation-service.json
 
-        # Store-reservation-service Swagger Docs
-        - id: store-reservation-service-swagger
-          uri: lb://store-reservation-service
-          predicates:
-            - Path=/store-reservation-service/v3/api-docs
-          filters:
-            - RewritePath=/store-reservation-service/v3/api-docs, /v3/api-docs
-
-        # Product-service API
+        # Product
         - id: product-service
           uri: lb://product-service
           predicates:
-            - Path=/v1/products/**
-          filters:
-            - RewritePath=/v1/products/(?<segment>.*), /${segment}
-
-        # Product-service Swagger Docs
-        - id: product-service-swagger
-          uri: lb://product-service
-          predicates:
-            - Path=/product-service/v3/api-docs
-          filters:
-            - RewritePath=/product-service/v3/api-docs, /v3/api-docs
+            - Path=/v1/products/**, /springdoc/openapi3-product-service.json
 
         # Product-reservation-service
         - id: product-reservation-service
           uri: lb://product-reservation-service
           predicates:
-            - Path=/v1/product-reservations/**
-          filters:
-            - RewritePath=/v1/product-reservations/(?<segment>.*), /${segment}
+            - Path=/v1/product-reservations/**, /springdoc/openapi3-product-reservation-service.json
 
-        # Product-reservation-service Swagger Docs
-        - id: product-reservation-service-swagger
-          uri: lb://product-reservation-service
-          predicates:
-            - Path=/product-reservation-service/v3/api-docs
-          filters:
-            - RewritePath=/product-reservation-service/v3/api-docs, /v3/api-docs
-
-        # Slack-service
+        # Slack
         - id: slack-service
           uri: lb://slack-service
           predicates:
-            - Path=/v1/slacks/**
-          filters:
-            - RewritePath=/v1/slacks/(?<segment>.*), /${segment}
-
-        # Slack-service Swagger Docs
-        - id: slack-service-swagger
-          uri: lb://slack-service
-          predicates:
-            - Path=/slack-service/v3/api-docs
-          filters:
-            - RewritePath=/slack-service/v3/api-docs, /v3/api-docs
+            - Path=/v1/slacks/**, /springdoc/openapi3-slack-service.json
 
       discovery:
         locator:
@@ -118,19 +58,25 @@ eureka:
       defaultZone: http://localhost:8761/eureka/
 
 springdoc:
-  api-docs:
-    path: /v3/api-docs
   swagger-ui:
-    urls:
-      - name: user-service
-        url: /v1/users/v3/api-docs
-      - name: store-service
-        url: /v1/stores/v3/api-docs
-      - name: store-reservation-service
-        url: /v1/store-reservations/v3/api-docs
-      - name: product-service
-        url: /v1/products/v3/api-docs
-      - name: product-reservation-service
-        url: /v1/product-reservations/v3/api-docs
-      - name: slack-service
-        url: /v1/slacks/v3/api-docs
+    urls[0]:
+      name: user-service
+      url: /springdoc/openapi3-user-service.json
+    urls[1]:
+      name: store-service
+      url: /springdoc/openapi3-store-service.json
+    urls[2]:
+      name: store-reservation-service
+      url: /springdoc/openapi3-store-reservation-service.json
+    urls[3]:
+      name: product-service
+      url: /springdoc/openapi3-product-service.json
+    urls[4]:
+      name: product-reservation-service
+      url: /springdoc/openapi3-product-reservation-service.json
+    urls[5]:
+      name: slack-service
+      url: /springdoc/openapi3-slack-service.json
+
+    #    use-root-path: true
+    path: /docs

--- a/product-reservation-service/build.gradle
+++ b/product-reservation-service/build.gradle
@@ -1,7 +1,5 @@
 plugins {
-    id 'java'
-    id 'org.springframework.boot'
-    id 'io.spring.dependency-management'
+    id 'com.epages.restdocs-api-spec' version "0.19.2"
 }
 
 ext {
@@ -33,4 +31,62 @@ dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
+}
+
+compileJava {
+    dependsOn 'clean'
+}
+
+test {
+    enabled = true;
+}
+
+postman {
+    baseUrl = 'http://localhost:8080'
+    title = 'PRODUCT RESERVATION API'
+    version = '1.0.0'
+}
+
+openapi3 {
+    servers = [
+            {
+                url = 'http://localhost:8080'
+            }
+    ]
+    title = 'PRODUCT RESERVATION API'
+    description = ''
+    version = '1.0.0'
+    format = 'json'
+}
+
+tasks.register('setDocs') {
+    dependsOn 'postman'
+    dependsOn 'openapi3'
+
+    doLast {
+        copy {
+            from "build/api-spec"
+            include "*.json"
+            include "*.yaml"
+            into "build/resources/main/static/springdoc"
+            rename { String fileName ->
+                if (fileName.endsWith('.json')) {
+                    return fileName.replace('.json', '-product-reservation-service.json')
+                } else if (fileName.endsWith('.yaml')) {
+                    return fileName.replace('.yaml', '-product-reservation-service.yml')
+                }
+                return fileName
+            }
+        }
+    }
+}
+
+// bootRun 실행 시 문서 생성 태스크를 실행
+bootRun {
+    dependsOn 'setDocs'
+}
+
+// bootJar 실행 시 문서 생성 태스크를 실행
+bootJar {
+    dependsOn 'setDocs'
 }

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -1,7 +1,5 @@
 plugins {
-    id 'java'
-    id 'org.springframework.boot'
-    id 'io.spring.dependency-management'
+    id 'com.epages.restdocs-api-spec' version "0.19.2"
 }
 
 ext {
@@ -33,4 +31,62 @@ dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
+}
+
+compileJava {
+    dependsOn 'clean'
+}
+
+test {
+    enabled = true;
+}
+
+postman {
+    baseUrl = 'http://localhost:8080'
+    title = 'PRODUCT API'
+    version = '1.0.0'
+}
+
+openapi3 {
+    servers = [
+            {
+                url = 'http://localhost:8080'
+            }
+    ]
+    title = 'PRODUCT API'
+    description = ''
+    version = '1.0.0'
+    format = 'json'
+}
+
+tasks.register('setDocs') {
+    dependsOn 'postman'
+    dependsOn 'openapi3'
+
+    doLast {
+        copy {
+            from "build/api-spec"
+            include "*.json"
+            include "*.yaml"
+            into "build/resources/main/static/springdoc"
+            rename { String fileName ->
+                if (fileName.endsWith('.json')) {
+                    return fileName.replace('.json', '-product-service.json')
+                } else if (fileName.endsWith('.yaml')) {
+                    return fileName.replace('.yaml', '-product-service.yml')
+                }
+                return fileName
+            }
+        }
+    }
+}
+
+// bootRun 실행 시 문서 생성 태스크를 실행
+bootRun {
+    dependsOn 'setDocs'
+}
+
+// bootJar 실행 시 문서 생성 태스크를 실행
+bootJar {
+    dependsOn 'setDocs'
 }

--- a/slack-service/build.gradle
+++ b/slack-service/build.gradle
@@ -59,7 +59,6 @@ openapi3 {
     format = 'json'
 }
 
-// task를 만듭니다.
 tasks.register('setDocs') {
     dependsOn 'postman'
     dependsOn 'openapi3'

--- a/slack-service/build.gradle
+++ b/slack-service/build.gradle
@@ -1,7 +1,5 @@
 plugins {
-    id 'java'
-    id 'org.springframework.boot'
-    id 'io.spring.dependency-management'
+    id 'com.epages.restdocs-api-spec' version "0.19.2"
 }
 
 ext {
@@ -33,4 +31,63 @@ dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
+}
+
+compileJava {
+    dependsOn 'clean'
+}
+
+test {
+    enabled = true;
+}
+
+postman {
+    baseUrl = 'http://localhost:8080'
+    title = 'SLACK API'
+    version = '1.0.0'
+}
+
+openapi3 {
+    servers = [
+            {
+                url = 'http://localhost:8080'
+            }
+    ]
+    title = 'SLACK API'
+    description = ''
+    version = '1.0.0'
+    format = 'json'
+}
+
+// task를 만듭니다.
+tasks.register('setDocs') {
+    dependsOn 'postman'
+    dependsOn 'openapi3'
+
+    doLast {
+        copy {
+            from "build/api-spec"
+            include "*.json"
+            include "*.yaml"
+            into "build/resources/main/static/springdoc"
+            rename { String fileName ->
+                if (fileName.endsWith('.json')) {
+                    return fileName.replace('.json', '-slack-service.json')
+                } else if (fileName.endsWith('.yaml')) {
+                    return fileName.replace('.yaml', '-slack-service.yml')
+                }
+                return fileName
+            }
+        }
+    }
+}
+
+// bootRun 실행 시 문서 생성 태스크를 실행
+bootRun {
+    dependsOn 'setDocs'
+}
+
+// bootJar 실행 시 문서 생성 태스크를 실행
+bootJar {
+    dependsOn 'setDocs'
 }

--- a/store-reservation-service/build.gradle
+++ b/store-reservation-service/build.gradle
@@ -1,7 +1,5 @@
 plugins {
-    id 'java'
-    id 'org.springframework.boot'
-    id 'io.spring.dependency-management'
+    id 'com.epages.restdocs-api-spec' version "0.19.2"
 }
 
 ext {
@@ -33,4 +31,62 @@ dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
+}
+
+compileJava {
+    dependsOn 'clean'
+}
+
+test {
+    enabled = true;
+}
+
+postman {
+    baseUrl = 'http://localhost:8080'
+    title = 'STORE RESERVATION API'
+    version = '1.0.0'
+}
+
+openapi3 {
+    servers = [
+            {
+                url = 'http://localhost:8080'
+            }
+    ]
+    title = 'STORE RESERVATION API'
+    description = ''
+    version = '1.0.0'
+    format = 'json'
+}
+
+tasks.register('setDocs') {
+    dependsOn 'postman'
+    dependsOn 'openapi3'
+
+    doLast {
+        copy {
+            from "build/api-spec"
+            include "*.json"
+            include "*.yaml"
+            into "build/resources/main/static/springdoc"
+            rename { String fileName ->
+                if (fileName.endsWith('.json')) {
+                    return fileName.replace('.json', '-store-reservation-service.json')
+                } else if (fileName.endsWith('.yaml')) {
+                    return fileName.replace('.yaml', '-store-reservation-service.yml')
+                }
+                return fileName
+            }
+        }
+    }
+}
+
+// bootRun 실행 시 문서 생성 태스크를 실행
+bootRun {
+    dependsOn 'setDocs'
+}
+
+// bootJar 실행 시 문서 생성 태스크를 실행
+bootJar {
+    dependsOn 'setDocs'
 }

--- a/store-service/build.gradle
+++ b/store-service/build.gradle
@@ -1,7 +1,5 @@
 plugins {
-    id 'java'
-    id 'org.springframework.boot'
-    id 'io.spring.dependency-management'
+    id 'com.epages.restdocs-api-spec' version "0.19.2"
 }
 
 ext {
@@ -34,4 +32,62 @@ dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
+}
+
+compileJava {
+    dependsOn 'clean'
+}
+
+test {
+    enabled = true;
+}
+
+postman {
+    baseUrl = 'http://localhost:8080'
+    title = 'STORE API'
+    version = '1.0.0'
+}
+
+openapi3 {
+    servers = [
+            {
+                url = 'http://localhost:8080'
+            }
+    ]
+    title = 'STORE API'
+    description = ''
+    version = '1.0.0'
+    format = 'json'
+}
+
+tasks.register('setDocs') {
+    dependsOn 'postman'
+    dependsOn 'openapi3'
+
+    doLast {
+        copy {
+            from "buildbuildbuild/api-spec"
+            include "*.json"
+            include "*.yaml"
+            into "build/resources/main/static/springdoc"
+            rename { String fileName ->
+                if (fileName.endsWith('.json')) {
+                    return fileName.replace('.json', '-store-service.json')
+                } else if (fileName.endsWith('.yaml')) {
+                    return fileName.replace('.yaml', '-store-service.yml')
+                }
+                return fileName
+            }
+        }
+    }
+}
+
+// bootRun 실행 시 문서 생성 태스크를 실행
+bootRun {
+    dependsOn 'setDocs'
+}
+
+// bootJar 실행 시 문서 생성 태스크를 실행
+bootJar {
+    dependsOn 'setDocs'
 }

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -64,7 +64,6 @@ openapi3 {
     format = 'json'
 }
 
-// task를 만듭니다.
 tasks.register('setDocs') {
     dependsOn 'postman'
     dependsOn 'openapi3'

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -1,23 +1,14 @@
 plugins {
-    id 'java'
-    id 'org.springframework.boot'
-    id 'io.spring.dependency-management'
+    id 'com.epages.restdocs-api-spec' version "0.19.2"
 }
 
 ext {
     set('springCloudVersion', "2024.0.1")
 }
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     // 공통 모듈
     implementation project(':common-module')
-
-    // SpringDoc OpenAPI
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 
     // validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -45,4 +36,63 @@ dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
+}
+
+compileJava {
+    dependsOn 'clean'
+}
+
+test {
+    enabled = true;
+}
+
+postman {
+    baseUrl = 'http://localhost:8080'
+    title = 'USER API'
+    version = '1.0.0'
+}
+
+openapi3 {
+    servers = [
+            {
+                url = 'http://localhost:8080'
+            }
+    ]
+    title = 'USER API'
+    description = ''
+    version = '1.0.0'
+    format = 'json'
+}
+
+// task를 만듭니다.
+tasks.register('setDocs') {
+    dependsOn 'postman'
+    dependsOn 'openapi3'
+
+    doLast {
+        copy {
+            from "build/api-spec"
+            include "*.json"
+            include "*.yaml"
+            into "build/resources/main/static/springdoc"
+            rename { String fileName ->
+                if (fileName.endsWith('.json')) {
+                    return fileName.replace('.json', '-user-service.json')
+                } else if (fileName.endsWith('.yaml')) {
+                    return fileName.replace('.yaml', '-user-service.yml')
+                }
+                return fileName
+            }
+        }
+    }
+}
+
+// bootRun 실행 시 문서 생성 태스크를 실행
+bootRun {
+    dependsOn 'setDocs'
+}
+
+// bootJar 실행 시 문서 생성 태스크를 실행
+bootJar {
+    dependsOn 'setDocs'
 }


### PR DESCRIPTION
### **📌 작업 내용**

테스트 코드 기반으로 Swagger UI에서 각 서비스의 API를 문서화하도록 수정

- As-is
    - swagger 문서 자동화
- To-be
    - 테스트 코드 기반으로 swagger 문서화

### **🧑‍💻 작업 유형**

- [ ]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  코드 리팩토링
- [ ]  문서 수정
- [x]  설정 변경
- [ ]  CI/CD 변경

### **📷 관련 이미지**

해당 Pull Request와 관련된 이미지가 있을 경우 여기에 첨부해주세요.

### **🚨 주의 사항**

1. 각 모듈에서 본인이 진행하는 DB 방식으로 수정하여 테스트 진행이 필요
2. 인텔리제이 'Edit configuration...'에서 'Add before launch task' 설정이 필요
2-1. 위 설정을 하지 않을 시, 각 서비스에 './gradlew :store-service:bootRun'을 해줘야 함
3. http://localhost:8080/docs 으로 접속하면 Swagger UI가 보임
- 추후에 root gradle과 서브 모듈 gradle 정리 필요 (root gradle에 의존적이지 않기 위해 dependency 수정 등)

### **🤔 토론**

기능을 추가하면서 생긴 고민을 작성해주세요.
