### PR TITLE
feat: slack 도메인 entity 구현

### DIFF
--- a/slack-service/src/main/java/com/monkey/slackservice/domain/slack/entity/SlackEntity.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/domain/slack/entity/SlackEntity.java
@@ -1,0 +1,35 @@
+package com.monkey.slackservice.domain.slack.entity;
+
+import com.monkey.commonmodule.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+@Table(name = "p_slack_message")
+@SQLRestriction("deleted_at is null")
+public class SlackEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID slackMessageId;
+
+    @Column(nullable = false)
+    private UUID userSlackId;
+
+    @Column(nullable = false)
+    private String slackMessage;
+
+    public static SlackEntity createSlackMessage(UUID slackId, String slackMessage) {
+        return SlackEntity.builder()
+                .userSlackId(slackId)
+                .slackMessage(slackMessage)
+                .build();
+    }
+}

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/domain/StoreReservation/entity/StoreReservationEntity.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/domain/StoreReservation/entity/StoreReservationEntity.java
@@ -12,9 +12,9 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
+@AllArgsConstructor
 @Table(name = "p_store_reservation")
 @SQLRestriction("deleted_at is null")
-@AllArgsConstructor
 public class StoreReservationEntity extends BaseEntity {
 
     @Id


### PR DESCRIPTION
### **📌 작업 내용**

- To-be
    - Slack 도메인의 Entity 를 구현하였습니다.

### **🧑‍💻 작업 유형**

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  코드 리팩토링
- [ ]  문서 수정
- [ ]  설정 변경
- [ ]  CI/CD 변경