### PR TITLE
feat: slack 도메인 Repository 구현

### DIFF
--- a/slack-service/src/main/java/com/monkey/slackservice/domain/slack/repository/SlackRepository.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/domain/slack/repository/SlackRepository.java
@@ -1,0 +1,7 @@
+package com.monkey.slackservice.domain.slack.repository;
+
+import com.monkey.slackservice.domain.slack.entity.SlackEntity;
+
+public interface SlackRepository {
+    SlackEntity save(SlackEntity slackEntity);
+}

--- a/slack-service/src/main/java/com/monkey/slackservice/infrastructure/persistence/slack/SlackJpaRepository.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/infrastructure/persistence/slack/SlackJpaRepository.java
@@ -1,0 +1,9 @@
+package com.monkey.slackservice.infrastructure.persistence.slack;
+
+import com.monkey.slackservice.domain.slack.entity.SlackEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface SlackJpaRepository extends JpaRepository<SlackEntity, UUID> {
+}

--- a/slack-service/src/main/java/com/monkey/slackservice/infrastructure/persistence/slack/SlackRepositoryImpl.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/infrastructure/persistence/slack/SlackRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.monkey.slackservice.infrastructure.persistence.slack;
+
+import com.monkey.slackservice.domain.slack.entity.SlackEntity;
+import com.monkey.slackservice.domain.slack.repository.SlackRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SlackRepositoryImpl implements SlackRepository {
+
+    private final SlackJpaRepository slackJpaRepository;
+
+    @Override
+    public SlackEntity save(SlackEntity slackEntity) {
+        return slackJpaRepository.save(slackEntity);
+    }
+}


### PR DESCRIPTION
### **📌 작업 내용**

- To-be
    - slack 도메인의 Repository 는 인터페이스, 구현체, JPA Repository 로 분리하여 설계하였습니다.

### **🧑‍💻 작업 유형**

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  코드 리팩토링
- [ ]  문서 수정
- [ ]  설정 변경
- [ ]  CI/CD 변경
