### PR TITLE
test: 팝업스토어 예약 도메인 더미데이터 코드 추가

### DIFF
--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationGetByIdDTOApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationGetByIdDTOApiV1.java
@@ -1,6 +1,6 @@
 package com.monkey.storereservationservice.application.dto.response;
 
-import com.monkey.storereservationservice.domain.StoreReservation.vo.StoreReservationStatus;
+import com.monkey.storereservationservice.domain.storereservation.vo.StoreReservationStatus;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationGetDTOApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationGetDTOApiV1.java
@@ -1,6 +1,6 @@
 package com.monkey.storereservationservice.application.dto.response;
 
-import com.monkey.storereservationservice.domain.StoreReservation.vo.StoreReservationStatus;
+import com.monkey.storereservationservice.domain.storereservation.vo.StoreReservationStatus;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationPostByIdCancelDTOApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationPostByIdCancelDTOApiV1.java
@@ -1,6 +1,6 @@
 package com.monkey.storereservationservice.application.dto.response;
 
-import com.monkey.storereservationservice.domain.StoreReservation.vo.StoreReservationStatus;
+import com.monkey.storereservationservice.domain.storereservation.vo.StoreReservationStatus;
 import lombok.*;
 
 import java.util.UUID;

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationPostDTOApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationPostDTOApiV1.java
@@ -1,6 +1,6 @@
 package com.monkey.storereservationservice.application.dto.response;
 
-import com.monkey.storereservationservice.domain.StoreReservation.vo.StoreReservationStatus;
+import com.monkey.storereservationservice.domain.storereservation.vo.StoreReservationStatus;
 import lombok.*;
 
 import java.util.UUID;

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/domain/StoreReservation/entity/StoreReservationEntity.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/domain/StoreReservation/entity/StoreReservationEntity.java
@@ -1,7 +1,7 @@
-package com.monkey.storereservationservice.domain.StoreReservation.entity;
+package com.monkey.storereservationservice.domain.storereservation.entity;
 
 import com.monkey.commonmodule.entity.BaseEntity;
-import com.monkey.storereservationservice.domain.StoreReservation.vo.StoreReservationStatus;
+import com.monkey.storereservationservice.domain.storereservation.vo.StoreReservationStatus;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLRestriction;

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/domain/StoreReservation/repository/StoreReservationRepository.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/domain/StoreReservation/repository/StoreReservationRepository.java
@@ -1,12 +1,10 @@
-package com.monkey.storereservationservice.domain.StoreReservation.repository;
+package com.monkey.storereservationservice.domain.storereservation.repository;
 
-import com.monkey.storereservationservice.domain.StoreReservation.entity.StoreReservationEntity;
+import com.monkey.storereservationservice.domain.storereservation.entity.StoreReservationEntity;
 
 import java.util.UUID;
 
 public interface StoreReservationRepository {
-
     StoreReservationEntity save(StoreReservationEntity storeReservationEntity);
-
     StoreReservationEntity findById(UUID storeReservationId);
 }

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/domain/StoreReservation/repository/StoreReservationRepository.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/domain/StoreReservation/repository/StoreReservationRepository.java
@@ -7,4 +7,5 @@ import java.util.UUID;
 public interface StoreReservationRepository {
     StoreReservationEntity save(StoreReservationEntity storeReservationEntity);
     StoreReservationEntity findById(UUID storeReservationId);
+    long count();
 }

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/domain/StoreReservation/vo/StoreReservationStatus.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/domain/StoreReservation/vo/StoreReservationStatus.java
@@ -1,4 +1,4 @@
-package com.monkey.storereservationservice.domain.StoreReservation.vo;
+package com.monkey.storereservationservice.domain.storereservation.vo;
 
 public enum StoreReservationStatus {
     SCHEDULED,

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/infrastructure/config/StoreReservationDataLoader.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/infrastructure/config/StoreReservationDataLoader.java
@@ -1,0 +1,31 @@
+package com.monkey.storereservationservice.infrastructure.config;
+
+import com.monkey.storereservationservice.domain.storereservation.entity.StoreReservationEntity;
+import com.monkey.storereservationservice.domain.storereservation.repository.StoreReservationRepository;
+import com.monkey.storereservationservice.domain.storereservation.vo.StoreReservationStatus;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.util.UUID;
+
+@Configuration
+@Profile("dev") // dev 프로필일 때만 Bean이 등록된다.
+public class StoreReservationDataLoader {
+
+    @Bean
+    public CommandLineRunner loadData(StoreReservationRepository storeReservationRepository) {
+        return args -> {
+            if (storeReservationRepository.count() == 0) { // 데이터가 없을 경우에만 더미 데이터 추가
+                StoreReservationEntity storeReservationEntity = StoreReservationEntity.builder()
+                        .timeSlotId(UUID.randomUUID())
+                        .userId(1L)
+                        .personCount(2)
+                        .status(StoreReservationStatus.SCHEDULED)
+                        .build();
+                storeReservationRepository.save(storeReservationEntity);
+            }
+        };
+    }
+}

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/infrastructure/persistence/storereservation/StoreReservationJpaRepository.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/infrastructure/persistence/storereservation/StoreReservationJpaRepository.java
@@ -1,6 +1,6 @@
 package com.monkey.storereservationservice.infrastructure.persistence.storereservation;
 
-import com.monkey.storereservationservice.domain.StoreReservation.entity.StoreReservationEntity;
+import com.monkey.storereservationservice.domain.storereservation.entity.StoreReservationEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/infrastructure/persistence/storereservation/StoreReservationRepositoryImpl.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/infrastructure/persistence/storereservation/StoreReservationRepositoryImpl.java
@@ -23,4 +23,9 @@ public class StoreReservationRepositoryImpl implements StoreReservationRepositor
         return storeReservationJpaRepository.findById(storeReservationId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않은 예약 ID입니다."));
     }
+
+    @Override
+    public long count() {
+        return storeReservationJpaRepository.count();
+    }
 }

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/infrastructure/persistence/storereservation/StoreReservationRepositoryImpl.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/infrastructure/persistence/storereservation/StoreReservationRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.monkey.storereservationservice.infrastructure.persistence.storereservation;
 
-import com.monkey.storereservationservice.domain.StoreReservation.entity.StoreReservationEntity;
-import com.monkey.storereservationservice.domain.StoreReservation.repository.StoreReservationRepository;
+import com.monkey.storereservationservice.domain.storereservation.entity.StoreReservationEntity;
+import com.monkey.storereservationservice.domain.storereservation.repository.StoreReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 

--- a/store-reservation-service/src/main/resources/application.yml
+++ b/store-reservation-service/src/main/resources/application.yml
@@ -16,6 +16,10 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
     show-sql: true
 
+#  더미데이터용 환경설정 *배포시 삭제 필요*
+  profiles:
+    active: dev
+
 server:
   port: 8083
 


### PR DESCRIPTION
### **📌 작업 내용**

이 PR에서 추가된 기능 또는 수정 사항에 대해 간략히 설명해주세요.

- To-be
    - 팝업스토어 예약 도메인의 더미데이터 코드 작성
    - domain 폴더의 StoreReservation 폴더명 소문자로 변경

### **🧑‍💻 작업 유형**

- [ ]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  코드 리팩토링
- [ ]  문서 수정
- [ ]  설정 변경
- [ ]  CI/CD 변경

### ** 작업 순서**

더미데이터에서 프로필을 "dev" 으로 설정하였기 때문에 설정 추가를 해야합니다.

1. yml 파일에 아래 설정 추가 (배포시 삭제)
```
spring:
  profiles:
    active: dev
```

2. Run -> Edit Configurations -> VM Option 에 아래 설정 추가

```
-Dspring.profiles.active=dev
```

3. 실행하면 DB에 더미데이터가 저장됩니다.

![image](https://github.com/user-attachments/assets/2fc8e6b4-c21c-4d76-9b5e-33e99464eefc)
