### PR TITLE
test: slack 도메인 더미데이터 코드 추가

### DIFF
--- a/slack-service/src/main/java/com/monkey/slackservice/domain/slack/entity/SlackEntity.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/domain/slack/entity/SlackEntity.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
-@Table(name = "p_slack_message")
+@Table(name = "p_slack")
 @SQLRestriction("deleted_at is null")
 public class SlackEntity extends BaseEntity {
 

--- a/slack-service/src/main/java/com/monkey/slackservice/domain/slack/repository/SlackRepository.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/domain/slack/repository/SlackRepository.java
@@ -4,4 +4,5 @@ import com.monkey.slackservice.domain.slack.entity.SlackEntity;
 
 public interface SlackRepository {
     SlackEntity save(SlackEntity slackEntity);
+    long count();
 }

--- a/slack-service/src/main/java/com/monkey/slackservice/infrastructure/config/SlackDataLoader.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/infrastructure/config/SlackDataLoader.java
@@ -1,0 +1,28 @@
+package com.monkey.slackservice.infrastructure.config;
+
+import com.monkey.slackservice.domain.slack.entity.SlackEntity;
+import com.monkey.slackservice.domain.slack.repository.SlackRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.util.UUID;
+
+@Configuration
+@Profile("dev")
+public class SlackDataLoader {
+
+    @Bean
+    public CommandLineRunner listen(SlackRepository slackRepository) {
+        return args -> {
+            if (slackRepository.count() == 0) { // 데이터가 없을 경우에만 더미 데이터 추가
+                SlackEntity slackEntity = SlackEntity.builder()
+                        .userSlackId(UUID.randomUUID())
+                        .slackMessage("예약이 완료되었습니다.")
+                        .build();
+                slackRepository.save(slackEntity);
+            }
+        };
+    }
+}

--- a/slack-service/src/main/java/com/monkey/slackservice/infrastructure/persistence/slack/SlackRepositoryImpl.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/infrastructure/persistence/slack/SlackRepositoryImpl.java
@@ -15,4 +15,9 @@ public class SlackRepositoryImpl implements SlackRepository {
     public SlackEntity save(SlackEntity slackEntity) {
         return slackJpaRepository.save(slackEntity);
     }
+
+    @Override
+    public long count() {
+        return slackJpaRepository.count();
+    }
 }

--- a/slack-service/src/main/resources/application.yml
+++ b/slack-service/src/main/resources/application.yml
@@ -16,6 +16,10 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
     show-sql: true
 
+  #  더미데이터용 환경설정 *배포시 삭제 필요*
+  profiles:
+    active: dev
+
 server:
   port: 8086
 


### PR DESCRIPTION
### **📌 작업 내용**

- To-be
    - slack 도메인의 더미데이터 코드 작성
    - slack 테이블명 변경 (slack_message에서 slack으로)

### **🧑‍💻 작업 유형**

- [ ]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  코드 리팩토링
- [ ]  문서 수정
- [ ]  설정 변경
- [ ]  CI/CD 변경

### **📷 관련 이미지**

더미데이터가 DB에 저장된 것을 확인할 수 있습니다.

![image](https://github.com/user-attachments/assets/2d6eaf5b-47d0-49e8-98c5-6011b827a93c)