### PR TITLE
feat: 공통모듈 Jitpack 배포

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ allprojects{
 
     repositories {
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 
     // 루트 프로젝트에서 테스트 비활성화

--- a/product-reservation-service/build.gradle
+++ b/product-reservation-service/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     implementation 'org.postgresql:postgresql:42.7.1'
+
+    implementation 'com.github.wonsongleejo:common-module:1.0.0'
 }
 
 dependencyManagement {

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     implementation 'org.postgresql:postgresql:42.7.1'
+
+    implementation 'com.github.wonsongleejo:common-module:1.0.0'
 }
 
 dependencyManagement {

--- a/slack-service/build.gradle
+++ b/slack-service/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     implementation 'org.postgresql:postgresql:42.7.1'
+
+    implementation 'com.github.wonsongleejo:common-module:1.0.0'
 }
 
 dependencyManagement {

--- a/store-reservation-service/build.gradle
+++ b/store-reservation-service/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     implementation 'org.postgresql:postgresql:42.7.1'
+
+    implementation 'com.github.wonsongleejo:common-module:1.0.0'
 }
 
 dependencyManagement {

--- a/store-service/build.gradle
+++ b/store-service/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     implementation 'org.hibernate.orm:hibernate-core:6.4.4.Final'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'com.h2database:h2'
+
+    implementation 'com.github.wonsongleejo:common-module:1.0.0'
 }
 
 dependencyManagement {

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.2'
+
+    implementation 'com.github.wonsongleejo:common-module:1.0.0'
 }
 
 dependencyManagement {


### PR DESCRIPTION
### **📌 작업 내용**

* common-module을 JitPack에 배포하고 기존에 있던 파일들 (BaseEntity, ResDTO 등) 옮겨놨습니다

* 공통모듈은 새로 생성한 common-module 레포지토리에서 확인 가능합니다

* 기존 프로젝트에서 jitpack 공통모듈 갖다 쓰기 위해 각 하위 모듈의 build.gradle에 아래 코드 추가했습니다
`implementation 'com.github.wonsongleejo:common-module:1.0.0'`

* 기존 프로젝트에서 jitpack 공통모듈 코드 쓰는 방법(예시):
`import com.monkey.common_module.dto.ResDTO;` 이렇게 import하면 외부라이브러리에 있는 공통모듈이 불러와집니다
(기존에 있던 코드 일일이 수정해야합니다...! -> commonmodule을 common_module로 수정)

* 배포한 모듈 주소: https://jitpack.io/#wonsongleejo/common-module

* 다 잘 작동하는지 확인 후에 기존 프로젝트에 있던 공통모듈 삭제하겠습니다

---


### **🚨 주의 사항**

공통 모듈 수정 시 이 방법대로 해주세요!!!! 

1. 수정한 내용 커밋,푸시

2. 아래 명령어 터미널에 순서대로 입력
<img width="300" alt="스크린샷 2025-04-16 오후 3 32 28" src="https://github.com/user-attachments/assets/2d0eb70b-50d6-43ea-97d4-4bfa4de68bf8" />

JitPack은 태그가 붙은 커밋만 라이브러리로 배포하기 때문에 이 과정이 필요하다고 합니다.

---


### **🧑‍💻 작업 유형**

- [x]  새로운 기능 추가
- [x]  문서 수정
- [x]  설정 변경