### PR TITLE
feat: 존재하는 timeslot인지 확인하는 로직 추가

### DIFF
--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV1.java
@@ -1,5 +1,6 @@
 package com.monkey.storereservationservice.application.service;
 
+import com.monkey.common_module.dto.ResponseCode;
 import com.monkey.storereservationservice.application.dto.request.ReqStoreReservationPostDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetByIdDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetDTOApiV1;
@@ -15,6 +16,9 @@ import com.monkey.storereservationservice.infrastructure.dto.response.ResStoreTi
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.monkey.common_module.exception.CustomException;
+
+import feign.FeignException;
 
 import java.util.List;
 import java.util.UUID;
@@ -32,8 +36,17 @@ public class StoreReservationServiceImplApiV1 implements StoreReservationService
     public ResStoreReservationPostDTOApiV1 create(ReqStoreReservationPostDTOApiV1 request) {
         ReqStoreReservationPostDTOApiV1.StoreReservation storeReservation = request.getStoreReservation();
 
+        // 존재하는 타임슬롯인지 확인
+        UUID timeSlotId = storeReservation.getTimeSlotId();
+        ResStoreTimeSlotDTOApiV1 timeSlot;
+        try {
+            timeSlot = storeClient.getTimeSlotById(timeSlotId);
+        } catch (FeignException.NotFound e) {
+            throw new CustomException(ResponseCode.OUT_OF_RESERVATION_TIME);
+        }
+
         StoreReservationEntity storeReservationEntity = StoreReservationEntity.createStoreReservation(
-                storeReservation.getTimeSlotId(),
+                timeSlotId,
                 1L,
                 storeReservation.getPersonCount(),
                 StoreReservationStatus.SCHEDULED


### PR DESCRIPTION
### **📌 작업 내용**

- As-is
    - timeslot에 어떤 UUID를 넣어도 팝업스토어 예약이 성공되었습니다.
- To-be
    - Feign Client로 timeslot DB에 존재하는 UUID 인지 확인하는 로직을 추가하였습니다.

### **🧑‍💻 작업 유형**

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  코드 리팩토링
- [ ]  문서 수정
- [ ]  설정 변경
- [ ]  CI/CD 변경
- [ ]  테스트 추가
- [ ]  테스트 수정

### **📷 관련 이미지**

![image](https://github.com/user-attachments/assets/fd1bd8e2-74c1-4ada-a880-c30600765ad8)
👉 예약성공

![image](https://github.com/user-attachments/assets/910f54fa-4616-41dc-9f64-87544db81c90)
👉 존재하지 않은 Timeslot ID 넣었을 때 실패