### PR TITLE
feat: 팝업스토어 예약 도메인 예약 상태 변경 구현

### DIFF
--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/request/ReqStoreReservationPutByIdStatusDTOApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/request/ReqStoreReservationPutByIdStatusDTOApiV1.java
@@ -1,0 +1,11 @@
+package com.monkey.storereservationservice.application.dto.request;
+
+import com.monkey.storereservationservice.domain.storereservation.vo.StoreReservationStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ReqStoreReservationPutByIdStatusDTOApiV1 {
+    @NotNull
+    private StoreReservationStatus storeReservationStatus;
+}

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/request/ReqStoreReservationPutByIdStatusDTOApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/request/ReqStoreReservationPutByIdStatusDTOApiV1.java
@@ -1,11 +1,26 @@
 package com.monkey.storereservationservice.application.dto.request;
 
 import com.monkey.storereservationservice.domain.storereservation.vo.StoreReservationStatus;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReqStoreReservationPutByIdStatusDTOApiV1 {
-    @NotNull
-    private StoreReservationStatus storeReservationStatus;
+
+    @NotNull(message = "예약 상태 정보는 필수입니다.")
+    @Valid
+    private StoreReservation storeReservation;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class StoreReservation {
+        @NotNull(message = "예약 상태는 필수입니다.")
+        private StoreReservationStatus status;
+    }
 }

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationPutByIdStatusDTOApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/response/ResStoreReservationPutByIdStatusDTOApiV1.java
@@ -8,13 +8,13 @@ import java.util.UUID;
 
 @Getter
 @Builder
-public class ResStoreReservationPostByIdCancelDTOApiV1 {
+public class ResStoreReservationPutByIdStatusDTOApiV1 {
 
     private StoreReservation storeReservation;
 
-    public static ResStoreReservationPostByIdCancelDTOApiV1 from(StoreReservationEntity storeReservationEntity) {
-        return ResStoreReservationPostByIdCancelDTOApiV1.builder()
-                .storeReservation(StoreReservation.from(storeReservationEntity))
+    public static ResStoreReservationPutByIdStatusDTOApiV1 from(StoreReservationEntity storeReservationentity) {
+        return ResStoreReservationPutByIdStatusDTOApiV1.builder()
+                .storeReservation(StoreReservation.from(storeReservationentity))
                 .build();
     }
 
@@ -27,10 +27,10 @@ public class ResStoreReservationPostByIdCancelDTOApiV1 {
         private UUID storeReservationId;
         private StoreReservationStatus status;
 
-        public static StoreReservation from(StoreReservationEntity storeReservationEntity) {
+        public static StoreReservation from(StoreReservationEntity storeReservationentity) {
             return StoreReservation.builder()
-                    .storeReservationId(storeReservationEntity.getStoreReservationId())
-                    .status(storeReservationEntity.getStatus())
+                    .storeReservationId(storeReservationentity.getStoreReservationId())
+                    .status(storeReservationentity.getStatus())
                     .build();
         }
     }

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceApiV1.java
@@ -3,7 +3,6 @@ package com.monkey.storereservationservice.application.service;
 import com.monkey.storereservationservice.application.dto.request.ReqStoreReservationPostDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetByIdDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetDTOApiV1;
-import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPostByIdCancelDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPostDTOApiV1;
 
 import java.util.UUID;
@@ -11,7 +10,6 @@ import java.util.UUID;
 public interface StoreReservationServiceApiV1 {
 
     ResStoreReservationPostDTOApiV1 create(ReqStoreReservationPostDTOApiV1 request);
-    ResStoreReservationPostByIdCancelDTOApiV1 cancel(UUID storeReservationId);
     ResStoreReservationGetDTOApiV1 getAll(Long userId, UUID storeId);
     ResStoreReservationGetByIdDTOApiV1 getById(UUID storeReservationId);
 }

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceApiV1.java
@@ -4,6 +4,8 @@ import com.monkey.storereservationservice.application.dto.request.ReqStoreReserv
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetByIdDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPostDTOApiV1;
+import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPutByIdStatusDTOApiV1;
+import com.monkey.storereservationservice.domain.storereservation.vo.StoreReservationStatus;
 
 import java.util.UUID;
 
@@ -12,4 +14,5 @@ public interface StoreReservationServiceApiV1 {
     ResStoreReservationPostDTOApiV1 create(ReqStoreReservationPostDTOApiV1 request);
     ResStoreReservationGetDTOApiV1 getAll(Long userId, UUID storeId);
     ResStoreReservationGetByIdDTOApiV1 getById(UUID storeReservationId);
+    ResStoreReservationPutByIdStatusDTOApiV1 changeStatus(UUID storeReservationId, StoreReservationStatus storeReservationStatus);
 }

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV1.java
@@ -1,9 +1,12 @@
 package com.monkey.storereservationservice.application.service;
 
+import com.monkey.common_module.dto.ResponseCode;
+import com.monkey.common_module.exception.CustomException;
 import com.monkey.storereservationservice.application.dto.request.ReqStoreReservationPostDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetByIdDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPostDTOApiV1;
+import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPutByIdStatusDTOApiV1;
 import com.monkey.storereservationservice.domain.storereservation.entity.StoreReservationEntity;
 import com.monkey.storereservationservice.domain.storereservation.repository.StoreReservationRepository;
 import com.monkey.storereservationservice.domain.storereservation.vo.StoreReservationStatus;
@@ -123,5 +126,19 @@ public class StoreReservationServiceImplApiV1 implements StoreReservationService
                                 .build()
                 )
                 .build();
+    }
+
+    @Override
+    public ResStoreReservationPutByIdStatusDTOApiV1 changeStatus(UUID storeReservationId, StoreReservationStatus storeReservationStatus) {
+        StoreReservationEntity storeReservationEntity = storeReservationRepository.findById(storeReservationId);
+
+        if (storeReservationEntity == null) {
+            throw new CustomException(ResponseCode.NOT_FOUND);
+        }
+
+        storeReservationEntity.changeStatus(storeReservationStatus);
+        storeReservationRepository.save(storeReservationEntity);
+
+        return ResStoreReservationPutByIdStatusDTOApiV1.from(storeReservationEntity);
     }
 }

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV1.java
@@ -3,7 +3,6 @@ package com.monkey.storereservationservice.application.service;
 import com.monkey.storereservationservice.application.dto.request.ReqStoreReservationPostDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetByIdDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetDTOApiV1;
-import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPostByIdCancelDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPostDTOApiV1;
 import com.monkey.storereservationservice.domain.storereservation.entity.StoreReservationEntity;
 import com.monkey.storereservationservice.domain.storereservation.repository.StoreReservationRepository;
@@ -53,14 +52,6 @@ public class StoreReservationServiceImplApiV1 implements StoreReservationService
         );
 
         return ResStoreReservationPostDTOApiV1.from(saved);
-    }
-
-    @Override
-    public ResStoreReservationPostByIdCancelDTOApiV1 cancel(UUID storeReservationId) {
-        StoreReservationEntity entity = storeReservationRepository.findById(storeReservationId);
-        entity.changeStatus(StoreReservationStatus.CANCELED);
-        storeReservationRepository.save(entity);
-        return ResStoreReservationPostByIdCancelDTOApiV1.from(entity);
     }
 
     @Override

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1.java
@@ -2,9 +2,11 @@ package com.monkey.storereservationservice.presentation.controller;
 
 import com.monkey.common_module.dto.ResDTO;
 import com.monkey.storereservationservice.application.dto.request.ReqStoreReservationPostDTOApiV1;
+import com.monkey.storereservationservice.application.dto.request.ReqStoreReservationPutByIdStatusDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetByIdDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPostDTOApiV1;
+import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPutByIdStatusDTOApiV1;
 import com.monkey.storereservationservice.application.service.StoreReservationServiceApiV1;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -53,6 +55,23 @@ public class StoreReservationControllerApiV1 {
             @PathVariable UUID storeReservationId
     ) {
         ResStoreReservationGetByIdDTOApiV1 resDto = storeReservationServiceApiV1.getById(storeReservationId);
+
+        return new ResponseEntity<>(
+                ResDTO.success(resDto),
+                HttpStatus.OK
+        );
+    }
+
+    // 예약 상태 변경
+    @PutMapping("/{storeReservationId}/status")
+    public ResponseEntity<ResDTO<ResStoreReservationPutByIdStatusDTOApiV1>> putByStatus(
+            @PathVariable UUID storeReservationId,
+            @Valid @RequestBody ReqStoreReservationPutByIdStatusDTOApiV1 request
+    ) {
+        ResStoreReservationPutByIdStatusDTOApiV1 resDto = storeReservationServiceApiV1.changeStatus(
+                storeReservationId,
+                request.getStoreReservation().getStatus()
+        );
 
         return new ResponseEntity<>(
                 ResDTO.success(resDto),

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1.java
@@ -4,7 +4,6 @@ import com.monkey.common_module.dto.ResDTO;
 import com.monkey.storereservationservice.application.dto.request.ReqStoreReservationPostDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetByIdDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetDTOApiV1;
-import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPostByIdCancelDTOApiV1;
 import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPostDTOApiV1;
 import com.monkey.storereservationservice.application.service.StoreReservationServiceApiV1;
 import jakarta.validation.Valid;
@@ -27,18 +26,6 @@ public class StoreReservationControllerApiV1 {
     public ResponseEntity<ResDTO<ResStoreReservationPostDTOApiV1>> postBy(@Valid @RequestBody ReqStoreReservationPostDTOApiV1 request) {
 
         ResStoreReservationPostDTOApiV1 resDto = storeReservationServiceApiV1.create(request);
-
-        return new ResponseEntity<>(
-                ResDTO.success(resDto),
-                HttpStatus.OK
-        );
-    }
-
-    // 예약 취소
-    @PostMapping("/{storeReservationId}/cancel")
-    public ResponseEntity<ResDTO<ResStoreReservationPostByIdCancelDTOApiV1>> cancelBy(@PathVariable UUID storeReservationId) {
-
-        ResStoreReservationPostByIdCancelDTOApiV1 resDto = storeReservationServiceApiV1.cancel(storeReservationId);
 
         return new ResponseEntity<>(
                 ResDTO.success(resDto),

--- a/store-reservation-service/src/test/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1Test.java
+++ b/store-reservation-service/src/test/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1Test.java
@@ -216,11 +216,22 @@ public class StoreReservationControllerApiV1Test {
                 );
     }
 
-    // 예약 취소
     @Test
-    public void testStoreReservationCancelSuccess() throws Exception {
+    public void testStoreReservationStatusUpdateSuccess() throws Exception {
+        // given
+        StoreReservationStatus newStatus = StoreReservationStatus.VISITED;
+        String requestJson = """
+        {
+            "storeReservation": {
+                "status": "%s"
+            }
+        }
+        """.formatted(newStatus.name());
+
         mockMvc.perform(
-                        RestDocumentationRequestBuilders.post("/v1/store-reservations/{reservationId}/cancel", savedId)
+                        RestDocumentationRequestBuilders.put("/v1/store-reservations/{reservationId}/status", savedId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestJson)
                 )
                 .andExpectAll(
                         MockMvcResultMatchers.status().isOk(),
@@ -228,13 +239,16 @@ public class StoreReservationControllerApiV1Test {
                 )
                 .andDo(
                         document(
-                                "STORE-RESERVATION 예약 취소 성공",
+                                "STORE-RESERVATION 예약 상태 변경 성공",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 resource(ResourceSnippetParameters.builder()
                                         .tag("STORE-RESERVATION v1")
-                                        .summary("팝업스토어 예약 취소")
-                                        .description("storeReservationID로 예약을 취소합니다.")
+                                        .summary("팝업스토어 예약 상태 변경")
+                                        .description("storeReservationID로 예약 상태를 변경합니다.")
+                                        .requestFields(
+                                                fieldWithPath("storeReservation.status").type(JsonFieldType.STRING).description("변경할 예약 상태 (예: SCHEDULED, CANCELED, VISITED, NO_SHOW)")
+                                        )
                                         .responseFields(
                                                 fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
                                                 fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),


### PR DESCRIPTION
### **📌 작업 내용**

- As-is
    - 예약 취소 API 만 구현된 상태였습니다.
- To-be
    - 예약 상태는 예약 성공, 예약 취소, 방문 완료, 노쇼 4가지이기 때문에 예약 취소 API를 삭제하고 예약 상태를 변경해주는 API를 구현하였습니다.
    - 테스트 코드도 작성하였습니다.

### **🧑‍💻 작업 유형**

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  코드 리팩토링
- [ ]  문서 수정
- [ ]  설정 변경
- [ ]  CI/CD 변경
- [X]  테스트 추가
- [X]  테스트 수정