### PR TITLE
feat: 상품 AOP 기반 X-User-Id 자동 처리 및 JPA Auditor 적용

### DIFF
--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     implementation 'org.postgresql:postgresql:42.7.1'
 }

--- a/product-service/src/main/java/com/monkey/productservice/application/service/ProductServiceApiV1.java
+++ b/product-service/src/main/java/com/monkey/productservice/application/service/ProductServiceApiV1.java
@@ -27,9 +27,7 @@ public class ProductServiceApiV1 {
     // 상품 등록
     public ResProductPostDTOApiV1 postBy(ReqProductPostDTOApiV1 reqDto) {
         ProductEntity productEntity = reqDto.getProduct().toEntity();
-        ProductEntity savedProductEntity = productRepository.save(productEntity);
-
-        return ResProductPostDTOApiV1.of(savedProductEntity);
+        return ResProductPostDTOApiV1.of(productRepository.save(productEntity));
     }
 
     // 상품 수정
@@ -63,9 +61,9 @@ public class ProductServiceApiV1 {
     }
 
     // 상품 삭제
-    public void deleteById(UUID productId) {
+    public void deleteById(UUID productId, Long userId) {
         ProductEntity productEntity = getActiveProductById(productId);
-        productEntity.delete(123L); // 추후에 인증 유저 ID로 교체해야됨
+        productEntity.delete(userId);
         productRepository.save(productEntity);
     }
 

--- a/product-service/src/main/java/com/monkey/productservice/domain/entity/ProductEntity.java
+++ b/product-service/src/main/java/com/monkey/productservice/domain/entity/ProductEntity.java
@@ -33,12 +33,4 @@ public class ProductEntity extends BaseEntity {
 
     @Column(nullable = false)
     private Integer purchaseLimitPerUser;
-
-    // 엔티티는 DTO랑 직접적으로 연결되면 안됨. 도메인 계층은 순수해야 함
-//    public ProductEntity(ReqProductPostDTOApiV1.Product productDto) {
-//        this.storeId = productDto.getStoreId();
-//        this.productName = productDto.getProductName();
-//        this.price = productDto.getPrice();
-//        this.quantity = productDto.getQuantity();
-//    }
 }

--- a/product-service/src/main/java/com/monkey/productservice/infrastructure/config/AuditingConfig.java
+++ b/product-service/src/main/java/com/monkey/productservice/infrastructure/config/AuditingConfig.java
@@ -1,0 +1,17 @@
+package com.monkey.productservice.infrastructure.config;
+
+import com.monkey.common_module.entity.AuditorAwareImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "auditorProvider")
+public class AuditingConfig {
+
+    @Bean(name = "auditorProvider")
+    public AuditorAware<Long> auditorProvider() {
+        return new AuditorAwareImpl();
+    }
+}

--- a/product-service/src/main/java/com/monkey/productservice/presentation/controller/ProductControllerApiV1.java
+++ b/product-service/src/main/java/com/monkey/productservice/presentation/controller/ProductControllerApiV1.java
@@ -25,6 +25,7 @@ public class ProductControllerApiV1 {
     // 상품 등록
     @PostMapping
     public ResponseEntity<ResDTO<ResProductPostDTOApiV1>> postBy(
+            @RequestHeader("X-User-Id") Long userId,
             @RequestBody @Valid ReqProductPostDTOApiV1 reqDto
             ) {
         ResProductPostDTOApiV1 resDto = productServiceApiV1.postBy(reqDto);
@@ -35,6 +36,7 @@ public class ProductControllerApiV1 {
     @PutMapping("/{productId}")
     public ResponseEntity<ResDTO<ResProductPutDTOApiV1>> putBy(
             @PathVariable UUID productId,
+            @RequestHeader("X-User-Id") Long userId,
             @RequestBody @Valid ReqProductPutDTOApiV1 reqDto
     ) {
         ResProductPutDTOApiV1 resDto = productServiceApiV1.putBy(productId, reqDto);
@@ -57,8 +59,8 @@ public class ProductControllerApiV1 {
 
     // 상품 삭제
     @DeleteMapping("/{productId}")
-    public ResponseEntity<ResDTO<Object>> deleteBy(@PathVariable UUID productId) {
-        productServiceApiV1.deleteById(productId);
+    public ResponseEntity<ResDTO<Object>> deleteBy(@PathVariable UUID productId, @RequestHeader("X-User-Id") Long userId) {
+        productServiceApiV1.deleteById(productId, userId);
         return new ResponseEntity<>(ResDTO.success(null), HttpStatus.OK);
     }
 }

--- a/product-service/src/test/java/com/monkey/productservice/presentation/controller/ProductControllerApiV1Test.java
+++ b/product-service/src/test/java/com/monkey/productservice/presentation/controller/ProductControllerApiV1Test.java
@@ -4,6 +4,7 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.SimpleType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.monkey.common_module.dto.ResDTO;
+import com.monkey.common_module.entity.AuditorAwareImpl;
 import com.monkey.productservice.ProductServiceApplication;
 import com.monkey.productservice.application.dto.request.ReqProductPostDTOApiV1;
 import com.monkey.productservice.application.dto.request.ReqProductPutDTOApiV1;
@@ -12,6 +13,7 @@ import com.monkey.productservice.domain.entity.ProductEntity;
 import com.monkey.productservice.infrastructure.feignclient.StoreFeignClientApiV1;
 import com.monkey.productservice.infrastructure.feignclient.dto.response.ResStoreClientGetByIdDTOApiV1;
 import com.monkey.productservice.infrastructure.persistence.ProductJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -55,6 +57,11 @@ public class ProductControllerApiV1Test {
     @Autowired
     private StoreFeignClientApiV1 storeClient;
 
+    @BeforeEach
+    void setupUserId() {
+        AuditorAwareImpl.setCurrentAuditor(123L);
+    }
+
     // 상품 등록
     @Test
     public void testProductPostSuccess() throws Exception {
@@ -75,6 +82,7 @@ public class ProductControllerApiV1Test {
         mockMvc.perform(
                         RestDocumentationRequestBuilders.post("/v1/products")
 //                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + resDto.getData().getAccessJwt())
+                                .header("X-User-Id", 123L)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(reqDtoJson)
                 )
@@ -141,6 +149,7 @@ public class ProductControllerApiV1Test {
         mockMvc.perform(
                 RestDocumentationRequestBuilders.put("/v1/products/{productId}", saved.getProductId())
 //                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + resDto.getData().getAccessJwt())
+                        .header("X-User-Id", 123L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(reqDtoJson)
                 )


### PR DESCRIPTION
### **📌 작업 내용**

* 모든 `@RestController` 메서드에 대해 `X-User-Id` 헤더를 감지하여 `ThreadLocal` 기반으로 자동 설정하는 AOP(`AuditorAspect`) 구현
* AuditorAwareImpl에 저장된 userId가 `@CreatedBy`, `@LastModifiedBy`로 주입
* 공통모듈에 AuditorAspect, AuditorAwareImpl 클래스 추가함

### **🧑‍💻 작업 유형**

- [X]  새로운 기능 추가
- [X]  코드 리팩토링
- [X]  테스트 수정

### **🚨 주의 사항 - AuditorAwareImpl 사용방법!**
1. build.gralde에 aop 의존성 추가 `implementation 'org.springframework.boot:spring-boot-starter-aop'`


 2. 각 서비스 모듈에서 infrastructure > config 패키지에 AuditingConfig 클래스 추가
```import com.monkey.common_module.entity.AuditorAwareImpl;
    import org.springframework.context.annotation.Bean;
    import org.springframework.context.annotation.Configuration;
    import org.springframework.data.domain.AuditorAware;
    import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
    
    @Configuration
    @EnableJpaAuditing(auditorAwareRef = "auditorProvider")
    public class AuditingConfig {

        @Bean(name = "auditorProvider")
        public AuditorAware<Long> auditorProvider() {
            return new AuditorAwareImpl();
        }
    }
```


3. 컨트롤러에서 각 메서드에 `@RequestHeader("X-User-Id") Long userId` 붙이면 끝

---

###  🐵 created_by, updated_by 적용되는 것 확인
<img width="710" alt="스크린샷 2025-04-22 오후 3 32 25" src="https://github.com/user-attachments/assets/4f644848-bdb1-4a7c-8155-2121ca6a87ad" />
