### PR TITLE
refactor: 상품 예약 시 예외처리 리팩토링, feignclient 전용 스토어 예약 목록 조회 API 추가

### DIFF
--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/validator/ProductReservationValidator.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/validator/ProductReservationValidator.java
@@ -53,20 +53,26 @@ public class ProductReservationValidator {
     // 스토어 예약여부 확인
     public void validateStoreMember(long userId, UUID storeId) {
         try {
-            var memberResponse = storeReservationClient.getReservationsByUserIdAndStoreId(userId, storeId);
+            var storeResponse = storeReservationClient.getReservationsByStoreId(storeId, userId);
 
-            if(memberResponse == null ||
-                    memberResponse.getData() == null ||
-                    memberResponse.getData().getStoreReservationList() == null ||
-                    memberResponse.getData().getStoreReservationList().isEmpty()) {
+            if (storeResponse == null || storeResponse.getData() == null ||
+                    storeResponse.getData().getStoreReservationList() == null) {
                 throw new CustomException(ResponseCode.NOT_STORE_MEMBER);
             }
-            boolean hasValidUser = memberResponse.getData().getStoreReservationList().stream()
-                    .anyMatch(reservation -> reservation.getUser() != null && reservation.getUser().getUserId() == userId);
 
-            if (!hasValidUser) {
+            boolean matched = storeResponse.getData().getStoreReservationList().stream()
+                    .anyMatch(res ->
+                            res.getUser() != null &&
+                                    res.getUser().getUserId() == userId &&
+                                    res.getTimeSlot() != null &&
+                                    res.getTimeSlot().getStore() != null &&
+                                    res.getTimeSlot().getStore().getStoreId().equals(storeId)
+                    );
+
+            if (!matched) {
                 throw new CustomException(ResponseCode.NOT_STORE_MEMBER);
             }
+
         } catch (CustomException e) {
             throw e;
         } catch (Exception e) {

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/feignclient/StoreReservationFeignClientApiV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/feignclient/StoreReservationFeignClientApiV1.java
@@ -9,9 +9,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.UUID;
 
-@FeignClient(name = "store-reservation-service", path = "/v1/store-reservations")
+@FeignClient(name = "store-reservation-service", path = "/v1/store-reservations/feign")
 @Profile("!test")
 public interface StoreReservationFeignClientApiV1 {
     @GetMapping
-    ResDTO<ResStoreReservationClientGetDTOApiV1> getReservationsByUserIdAndStoreId(@RequestParam Long userId, @RequestParam UUID storeId);
+    ResDTO<ResStoreReservationClientGetDTOApiV1> getReservationsByStoreId(@RequestParam UUID storeId, @RequestParam long userId);
 }

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/feignclient/dto/response/ResStoreReservationClientGetDTOApiV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/feignclient/dto/response/ResStoreReservationClientGetDTOApiV1.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @NoArgsConstructor
@@ -19,14 +20,32 @@ public class ResStoreReservationClientGetDTOApiV1 {
     @AllArgsConstructor
     @Builder
     public static class StoreReservation {
+        private UUID storeReservationId;
+        private TimeSlot timeSlot;
         private User user;
 
         @Getter
         @NoArgsConstructor
         @AllArgsConstructor
         @Builder
+        public static class TimeSlot {
+            private Store store;
+
+            @Getter
+            @NoArgsConstructor
+            @AllArgsConstructor
+            @Builder
+            public static class Store {
+                private UUID storeId;
+            }
+        }
+
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Builder
         public static class User {
-            private long userId;
+            private Long userId;
         }
     }
 }

--- a/product-reservation-service/src/test/java/com/monkey/productreservationservice/presentation/controller/ProductReservationControllerApiV1Test.java
+++ b/product-reservation-service/src/test/java/com/monkey/productreservationservice/presentation/controller/ProductReservationControllerApiV1Test.java
@@ -97,7 +97,7 @@ public class ProductReservationControllerApiV1Test {
                                 .build()
                 ));
 
-        given(storeReservationClient.getReservationsByUserIdAndStoreId(testUserId, testStoreId))
+        given(storeReservationClient.getReservationsByStoreId(testStoreId, testUserId))
                 .willReturn(ResDTO.success(
                         ResStoreReservationClientGetDTOApiV1.builder()
                                 .storeReservationList(List.of(
@@ -105,6 +105,15 @@ public class ProductReservationControllerApiV1Test {
                                                 .user(
                                                         ResStoreReservationClientGetDTOApiV1.StoreReservation.User.builder()
                                                                 .userId(testUserId)
+                                                                .build()
+                                                )
+                                                .timeSlot(
+                                                        ResStoreReservationClientGetDTOApiV1.StoreReservation.TimeSlot.builder()
+                                                                .store(
+                                                                        ResStoreReservationClientGetDTOApiV1.StoreReservation.TimeSlot.Store.builder()
+                                                                                .storeId(testStoreId)
+                                                                                .build()
+                                                                )
                                                                 .build()
                                                 )
                                                 .build()

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceApiV1.java
@@ -15,4 +15,5 @@ public interface StoreReservationServiceApiV1 {
     ResStoreReservationGetDTOApiV1 getAll(UserContext userContext, UUID storeId);
     ResStoreReservationGetByIdDTOApiV1 getById(UserContext userContext, UUID storeReservationId);
     ResStoreReservationPutByIdStatusDTOApiV1 changeStatus(UserContext userContext, UUID storeReservationId, StoreReservationStatus status);
+    ResStoreReservationGetDTOApiV1 getAllByUserIdAndStoreId(Long userId, UUID storeId);
 }

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV1.java
@@ -122,4 +122,59 @@ public class StoreReservationServiceImplApiV1 implements StoreReservationService
         entity.changeStatus(status);
         return ResStoreReservationPutByIdStatusDTOApiV1.from(storeReservationRepository.save(entity));
     }
+
+    // feignClient: 상품 예약 시 스토어 예약내역 전체 조회 -> 스토어 예약한 회원인지 확인
+    @Override
+    public ResStoreReservationGetDTOApiV1 getAllByUserIdAndStoreId(Long userId, UUID storeId) {
+        List<ResStoreReservationGetDTOApiV1.StoreReservation> list = storeReservationRepository.findAll().stream()
+                .filter(res -> res.getUserId().equals(userId)) // userId 기준 필터링
+                .map(entity -> {
+                    try {
+                        ResStoreTimeSlotDTOApiV1 timeSlotResponse = storeClient.getTimeSlotById(entity.getTimeSlotId());
+                        if (timeSlotResponse == null || timeSlotResponse.getData() == null) {
+                            throw new RuntimeException("TimeSlot not found: " + entity.getTimeSlotId());
+                        }
+
+                        ResStoreTimeSlotDTOApiV1.StoreTimeSlot timeSlot = timeSlotResponse.getData().getStoreTimeSlot();
+
+                        return ResStoreReservationGetDTOApiV1.StoreReservation.builder()
+                                .storeReservationId(entity.getStoreReservationId())
+                                .status(entity.getStatus())
+                                .timeSlot(
+                                        ResStoreReservationGetDTOApiV1.StoreReservation.TimeSlot.builder()
+                                                .store(
+                                                        ResStoreReservationGetDTOApiV1.StoreReservation.TimeSlot.Store.builder()
+                                                                .storeId(timeSlot.getStoreId())
+                                                                .build()
+                                                )
+                                                .date(timeSlot.getSlotDate())
+                                                .entryTime(timeSlot.getEntryTime())
+                                                .exitTime(timeSlot.getExitTime())
+                                                .build()
+                                )
+                                .user(
+                                        ResStoreReservationGetDTOApiV1.StoreReservation.User.builder()
+                                                .userId(userId)
+                                                .userName("unknown") // 필요시 FeignClient로 조회 가능
+                                                .build()
+                                )
+                                .build();
+                    } catch (Exception e) {
+                        return null;
+                    }
+                })
+                .filter(res ->
+                        res != null &&
+                                res.getTimeSlot() != null &&
+                                res.getTimeSlot().getStore() != null &&
+                                res.getTimeSlot().getStore().getStoreId().equals(storeId)
+                )
+                .toList();
+
+        return ResStoreReservationGetDTOApiV1.builder()
+                .storeReservationList(list)
+                .build();
+    }
+
+
 }

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1.java
@@ -61,4 +61,14 @@ public class StoreReservationControllerApiV1 {
         );
         return ResponseEntity.ok(ResDTO.success(resDto));
     }
+
+    // feignClient: 상품 예약 시 스토어 예약내역 전체 조회 -> 스토어 예약한 회원인지 확인
+    @GetMapping("/feign")
+    public ResponseEntity<ResDTO<ResStoreReservationGetDTOApiV1>> getAllByUserIdAndStoreId(
+            @RequestParam UUID storeId,
+            @RequestParam Long userId
+    ) {
+        ResStoreReservationGetDTOApiV1 resDto = storeReservationServiceApiV1.getAllByUserIdAndStoreId(userId, storeId);
+        return ResponseEntity.ok(ResDTO.success(resDto));
+    }
 }


### PR DESCRIPTION
### **📌 작업 내용**

* 상품 예약 시 예외처리 리팩토링
* 상품 예약 검증용 스토어 예약 목록 조회 API 추가

- As-is
    - 상품 예약 시 스토어를 예약한 회원인지 검증하는 과정에서 에러 발생
    - 상품 예약 도메인에서 스토어 예약 도메인을 통해 유저 ID + 스토어 ID로 예약 내역을 조회하는 API 필요, 그러나 기존 컨트롤러(`/v1/store-reservations`)는 `UserContext` 기반으로 동작하여 feignClient 요청을 통해 정보를 얻기 어려웠음
- To-be
    - `/v1/store-reservations/feign` 경로로 새로운 Feign 전용 조회 API 추가


### **🧑‍💻 작업 유형**

- [x]  코드 리팩토링
- [x]  테스트 수정


### **🤔 토론**

새로운 대안이나 의견 있으시면 언제든 말씀해주세요!!
