### PR TITLE
feat: 상품/상품예약내역 전체조회 페이징 처리

### DIFF
--- a/product-reservation-service/build.gradle
+++ b/product-reservation-service/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     // 공통 모듈
-    implementation 'com.github.wonsongleejo:common-module:1.0.0'
+    implementation 'com.github.wonsongleejo:common-module:1.0.1'
 
     // SpringDoc OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/dto/response/ResProductReservationGetDTOApiV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/dto/response/ResProductReservationGetDTOApiV1.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.UUID;
@@ -17,11 +18,33 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class ResProductReservationGetDTOApiV1 {
     private List<ProductReservation> productReservationList;
+    private PageInfo pageInfo;
 
-    public static ResProductReservationGetDTOApiV1 of(List<ProductReservationEntity> productReservationEntityList) {
+    public static ResProductReservationGetDTOApiV1 of(Page<ProductReservationEntity> page) {
         return ResProductReservationGetDTOApiV1.builder()
-                .productReservationList(ProductReservation.from(productReservationEntityList))
+                .productReservationList(ProductReservation.from(page.getContent()))
+                .pageInfo(PageInfo.from(page))
                 .build();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PageInfo {
+        private int page;
+        private int size;
+        private int totalPages;
+        private long totalElements;
+
+        public static PageInfo from(Page<?> page) {
+            return PageInfo.builder()
+                    .page(page.getNumber())
+                    .size(page.getSize())
+                    .totalPages(page.getTotalPages())
+                    .totalElements(page.getTotalElements())
+                    .build();
+        }
     }
 
     @Getter

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/service/ProductReservationServiceApiV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/service/ProductReservationServiceApiV1.java
@@ -16,9 +16,10 @@ import com.monkey.productreservationservice.infrastructure.feignclient.dto.respo
 import com.monkey.productreservationservice.infrastructure.feignclient.dto.response.ResStoreClientGetByIdDTOApiV1;
 import com.monkey.productreservationservice.infrastructure.feignclient.dto.response.ResUserClientGetByIdDTOApiV1;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -57,9 +58,9 @@ public class ProductReservationServiceApiV1 {
     }
 
     // 예약내역 전체 조회
-    public ResProductReservationGetDTOApiV1 getBy() {
-        List<ProductReservationEntity> productReservationList = productReservationRepository.findAllByIsDeletedFalse();
-        return ResProductReservationGetDTOApiV1.of(productReservationList);
+    public ResProductReservationGetDTOApiV1 getBy(Pageable pageable) {
+        Page<ProductReservationEntity> productReservationPage = productReservationRepository.findAllByIsDeletedFalse(pageable);
+        return ResProductReservationGetDTOApiV1.of(productReservationPage);
     }
 
     // 예약내역 단건 조회

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/domain/repository/ProductReservationRepository.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/domain/repository/ProductReservationRepository.java
@@ -1,6 +1,8 @@
 package com.monkey.productreservationservice.domain.repository;
 
 import com.monkey.productreservationservice.domain.entity.ProductReservationEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,5 +12,6 @@ public interface ProductReservationRepository {
     ProductReservationEntity save(ProductReservationEntity entity);
     Optional<ProductReservationEntity> findByProductReservationIdAndIsDeletedFalse(UUID productReservationId);
     List<ProductReservationEntity> findAllByIsDeletedFalse();
+    Page<ProductReservationEntity> findAllByIsDeletedFalse(Pageable pageable);
     boolean existsByUserIdAndProductIdAndIsDeletedFalse(long userId, UUID productId);
 }

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/persistence/ProductReservationJpaRepository.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/persistence/ProductReservationJpaRepository.java
@@ -1,6 +1,8 @@
 package com.monkey.productreservationservice.infrastructure.persistence;
 
 import com.monkey.productreservationservice.domain.entity.ProductReservationEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,5 +12,6 @@ import java.util.UUID;
 public interface ProductReservationJpaRepository extends JpaRepository<ProductReservationEntity, UUID> {
     Optional<ProductReservationEntity> findByProductReservationIdAndIsDeletedFalse(UUID productReservationId);
     List<ProductReservationEntity> findAllByIsDeletedFalse();
+    Page<ProductReservationEntity> findAllByIsDeletedFalse(Pageable pageable);
     boolean existsByUserIdAndProductIdAndIsDeletedFalse(long userId, UUID productId);
 }

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/persistence/ProductReservationRepositoryImpl.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/persistence/ProductReservationRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.monkey.productreservationservice.infrastructure.persistence;
 import com.monkey.productreservationservice.domain.entity.ProductReservationEntity;
 import com.monkey.productreservationservice.domain.repository.ProductReservationRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -27,6 +29,11 @@ public class ProductReservationRepositoryImpl implements ProductReservationRepos
     @Override
     public List<ProductReservationEntity> findAllByIsDeletedFalse() {
         return productReservationJpaRepository.findAllByIsDeletedFalse();
+    }
+
+    @Override
+    public Page<ProductReservationEntity> findAllByIsDeletedFalse(Pageable pageable) {
+        return productReservationJpaRepository.findAllByIsDeletedFalse(pageable);
     }
 
     @Override

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/presentation/controller/ProductReservationControllerApiV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/presentation/controller/ProductReservationControllerApiV1.java
@@ -9,6 +9,7 @@ import com.monkey.productreservationservice.application.dto.response.ResProductR
 import com.monkey.productreservationservice.application.service.ProductReservationServiceApiV1;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -44,8 +45,8 @@ public class ProductReservationControllerApiV1 {
 
     // 예약내역 전체 조회
     @GetMapping
-    public ResponseEntity<ResDTO<ResProductReservationGetDTOApiV1>> getBy() {
-        ResProductReservationGetDTOApiV1 resDto = productReservationService.getBy();
+    public ResponseEntity<ResDTO<ResProductReservationGetDTOApiV1>> getBy(Pageable pageable) {
+        ResProductReservationGetDTOApiV1 resDto = productReservationService.getBy(pageable);
         return new ResponseEntity<>(ResDTO.success(resDto), HttpStatus.OK);
     }
 

--- a/product-reservation-service/src/test/java/com/monkey/productreservationservice/presentation/controller/ProductReservationControllerApiV1Test.java
+++ b/product-reservation-service/src/test/java/com/monkey/productreservationservice/presentation/controller/ProductReservationControllerApiV1Test.java
@@ -293,7 +293,7 @@ public class ProductReservationControllerApiV1Test {
     // 예약 전체 조회
     @Test
     public void testProductReservationGetSuccess() throws Exception {
-        List<ProductReservationEntity> savedList = productReservationJpaRepository.findAllByIsDeletedFalse();
+        createProductReservation(ProductReservationStatus.PENDING_PICKUP);
 
         mockMvc.perform(
                         RestDocumentationRequestBuilders.get("/v1/product-reservations")
@@ -304,7 +304,8 @@ public class ProductReservationControllerApiV1Test {
                         MockMvcResultMatchers.status().isOk(),
                         MockMvcResultMatchers.jsonPath("code").value("000"),
                         MockMvcResultMatchers.jsonPath("data.productReservationList").isArray(),
-                        MockMvcResultMatchers.jsonPath("data.productReservationList.length()").value(savedList.size())
+                        MockMvcResultMatchers.jsonPath("data.pageInfo").exists(),
+                        MockMvcResultMatchers.jsonPath("data.pageInfo.size").value(10)
                 )
                 .andDo(
                         document("상품 예약 전체 조회 성공",
@@ -331,7 +332,12 @@ public class ProductReservationControllerApiV1Test {
                                                 fieldWithPath("data.productReservationList[].userId").type(JsonFieldType.NUMBER).description("유저 ID"),
                                                 fieldWithPath("data.productReservationList[].storeId").type(JsonFieldType.STRING).description("스토어 ID"),
                                                 fieldWithPath("data.productReservationList[].quantity").type(JsonFieldType.NUMBER).description("예약 수량"),
-                                                fieldWithPath("data.productReservationList[].status").type(JsonFieldType.STRING).description("예약 상태")
+                                                fieldWithPath("data.productReservationList[].status").type(JsonFieldType.STRING).description("예약 상태"),
+
+                                                fieldWithPath("data.pageInfo.page").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                                                fieldWithPath("data.pageInfo.size").type(JsonFieldType.NUMBER).description("요청한 페이지 사이즈"),
+                                                fieldWithPath("data.pageInfo.totalPages").type(JsonFieldType.NUMBER).description("총 페이지 수"),
+                                                fieldWithPath("data.pageInfo.totalElements").type(JsonFieldType.NUMBER).description("전체 예약 수")
                                         )
                                         .build()
                                 )

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     // 공통 모듈
-    implementation 'com.github.wonsongleejo:common-module:1.0.0'
+    implementation 'com.github.wonsongleejo:common-module:1.0.1'
 
     // SpringDoc OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'

--- a/product-service/src/main/java/com/monkey/productservice/application/dto/response/ResProductGetDTOApiV1.java
+++ b/product-service/src/main/java/com/monkey/productservice/application/dto/response/ResProductGetDTOApiV1.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.UUID;
@@ -16,11 +17,33 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class ResProductGetDTOApiV1 {
     private List<Product> productList;
+    private PageInfo pageInfo;
 
-    public static ResProductGetDTOApiV1 of(List<ProductEntity> productEntityList) {
+    public static ResProductGetDTOApiV1 of(Page<ProductEntity> productPage) {
         return ResProductGetDTOApiV1.builder()
-                .productList(Product.from(productEntityList))
+                .productList(Product.from(productPage.getContent()))
+                .pageInfo(PageInfo.from(productPage))
                 .build();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PageInfo {
+        private int page;
+        private int size;
+        private int totalPages;
+        private long totalElements;
+
+        public static PageInfo from(Page<?> page) {
+            return PageInfo.builder()
+                    .page(page.getNumber())
+                    .size(page.getSize())
+                    .totalPages(page.getTotalPages())
+                    .totalElements(page.getTotalElements())
+                    .build();
+        }
     }
 
     @Getter

--- a/product-service/src/main/java/com/monkey/productservice/application/service/ProductServiceApiV1.java
+++ b/product-service/src/main/java/com/monkey/productservice/application/service/ProductServiceApiV1.java
@@ -17,7 +17,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.UUID;
 
 @Service

--- a/product-service/src/main/java/com/monkey/productservice/application/service/ProductServiceApiV1.java
+++ b/product-service/src/main/java/com/monkey/productservice/application/service/ProductServiceApiV1.java
@@ -13,6 +13,8 @@ import com.monkey.productservice.domain.repository.ProductRepository;
 import com.monkey.productservice.infrastructure.feignclient.StoreFeignClientApiV1;
 import com.monkey.productservice.infrastructure.feignclient.dto.response.ResStoreClientGetByIdDTOApiV1;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -41,9 +43,9 @@ public class ProductServiceApiV1 {
     }
 
     // 상품 전체 조회
-    public ResProductGetDTOApiV1 getBy() {
-        List<ProductEntity> productList = productRepository.findAllByIsDeletedFalse();
-        return ResProductGetDTOApiV1.of(productList);
+    public ResProductGetDTOApiV1 getBy(Pageable pageable) {
+        Page<ProductEntity> productPage = productRepository.findAllByIsDeletedFalse(pageable);
+        return ResProductGetDTOApiV1.of(productPage);
     }
 
     // 상품 단건 조회

--- a/product-service/src/main/java/com/monkey/productservice/domain/repository/ProductRepository.java
+++ b/product-service/src/main/java/com/monkey/productservice/domain/repository/ProductRepository.java
@@ -1,6 +1,8 @@
 package com.monkey.productservice.domain.repository;
 
 import com.monkey.productservice.domain.entity.ProductEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +12,5 @@ public interface ProductRepository {
     ProductEntity save(ProductEntity productEntity);
     Optional<ProductEntity> findByProductIdAndIsDeletedFalse(UUID productId);
     List<ProductEntity> findAllByIsDeletedFalse();
+    Page<ProductEntity> findAllByIsDeletedFalse(Pageable pageable);
 }

--- a/product-service/src/main/java/com/monkey/productservice/infrastructure/persistence/ProductJpaRepository.java
+++ b/product-service/src/main/java/com/monkey/productservice/infrastructure/persistence/ProductJpaRepository.java
@@ -1,6 +1,8 @@
 package com.monkey.productservice.infrastructure.persistence;
 
 import com.monkey.productservice.domain.entity.ProductEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,4 +12,5 @@ import java.util.UUID;
 public interface ProductJpaRepository extends JpaRepository<ProductEntity, UUID> {
     Optional<ProductEntity> findByProductIdAndIsDeletedFalse(UUID productId);
     List<ProductEntity> findAllByIsDeletedFalse();
+    Page<ProductEntity> findAllByIsDeletedFalse(Pageable pageable);
 }

--- a/product-service/src/main/java/com/monkey/productservice/infrastructure/persistence/ProductRepositoryImpl.java
+++ b/product-service/src/main/java/com/monkey/productservice/infrastructure/persistence/ProductRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.monkey.productservice.infrastructure.persistence;
 import com.monkey.productservice.domain.entity.ProductEntity;
 import com.monkey.productservice.domain.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -27,5 +29,10 @@ public class ProductRepositoryImpl implements ProductRepository {
     @Override
     public List<ProductEntity> findAllByIsDeletedFalse() {
         return productJpaRepository.findAllByIsDeletedFalse();
+    }
+
+    @Override
+    public Page<ProductEntity> findAllByIsDeletedFalse(Pageable pageable) {
+        return productJpaRepository.findAllByIsDeletedFalse(pageable);
     }
 }

--- a/product-service/src/main/java/com/monkey/productservice/presentation/controller/ProductControllerApiV1.java
+++ b/product-service/src/main/java/com/monkey/productservice/presentation/controller/ProductControllerApiV1.java
@@ -10,6 +10,7 @@ import com.monkey.productservice.application.dto.response.ResProductPutDTOApiV1;
 import com.monkey.productservice.application.service.ProductServiceApiV1;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -45,8 +46,8 @@ public class ProductControllerApiV1 {
 
     // 상품 전체 조회
     @GetMapping
-    public ResponseEntity<ResDTO<ResProductGetDTOApiV1>> getBy() {
-        ResProductGetDTOApiV1 resDto = productServiceApiV1.getBy();
+    public ResponseEntity<ResDTO<ResProductGetDTOApiV1>> getBy(Pageable pageable) {
+        ResProductGetDTOApiV1 resDto = productServiceApiV1.getBy(pageable);
         return new ResponseEntity<>(ResDTO.success(resDto), HttpStatus.OK);
     }
 

--- a/product-service/src/test/java/com/monkey/productservice/presentation/controller/ProductControllerApiV1Test.java
+++ b/product-service/src/test/java/com/monkey/productservice/presentation/controller/ProductControllerApiV1Test.java
@@ -271,6 +271,7 @@ public class ProductControllerApiV1Test {
                         MockMvcResultMatchers.status().isOk(),
                         MockMvcResultMatchers.jsonPath("code").value("000"),
                         MockMvcResultMatchers.jsonPath("data.productList").isArray(),
+                        MockMvcResultMatchers.jsonPath("data.pageInfo").exists(),
                         MockMvcResultMatchers.jsonPath("data.productList.length()").value(savedList.size())
                 )
                 .andDo(
@@ -298,7 +299,12 @@ public class ProductControllerApiV1Test {
                                                 fieldWithPath("data.productList[].productName").type(JsonFieldType.STRING).description("상품명"),
                                                 fieldWithPath("data.productList[].price").type(JsonFieldType.NUMBER).description("가격"),
                                                 fieldWithPath("data.productList[].quantity").type(JsonFieldType.NUMBER).description("수량"),
-                                                fieldWithPath("data.productList[].purchaseLimitPerUser").type(JsonFieldType.NUMBER).description("1인당 구매 제한")
+                                                fieldWithPath("data.productList[].purchaseLimitPerUser").type(JsonFieldType.NUMBER).description("1인당 구매 제한"),
+
+                                                fieldWithPath("data.pageInfo.page").type(JsonFieldType.NUMBER).description("현재 페이지 번호"),
+                                                fieldWithPath("data.pageInfo.size").type(JsonFieldType.NUMBER).description("요청한 페이지 사이즈"),
+                                                fieldWithPath("data.pageInfo.totalPages").type(JsonFieldType.NUMBER).description("총 페이지 수"),
+                                                fieldWithPath("data.pageInfo.totalElements").type(JsonFieldType.NUMBER).description("전체 상품 개수")
                                         )
                                         .build()
                                 )

--- a/product-service/src/test/java/com/monkey/productservice/presentation/controller/ProductControllerApiV1Test.java
+++ b/product-service/src/test/java/com/monkey/productservice/presentation/controller/ProductControllerApiV1Test.java
@@ -272,7 +272,7 @@ public class ProductControllerApiV1Test {
                         MockMvcResultMatchers.jsonPath("code").value("000"),
                         MockMvcResultMatchers.jsonPath("data.productList").isArray(),
                         MockMvcResultMatchers.jsonPath("data.pageInfo").exists(),
-                        MockMvcResultMatchers.jsonPath("data.productList.length()").value(savedList.size())
+                        MockMvcResultMatchers.jsonPath("data.pageInfo.size").value(10)
                 )
                 .andDo(
                         document("상품 전체 조회 성공",


### PR DESCRIPTION
### **📌 작업 내용**

* 상품/상품예약 도메인의 전체조회에 페이징 처리 (자동으로 size=10/30/50만 허용, 그 외 값은 10으로 고정)

* 공통 페이징 설정을 적용하여 모든 도메인에서 Pageable 파라미터를 동일한 방식으로 처리할 수 있도록 구현
  * 공통모듈에 `WebMvcConfig`, `CustomPageableResolver` 클래스 추가한 후 태그 버전 올려서 배포했습니다 (tag 1.0.1)
  * 각 도메인에서 별도의 설정 없이 `Pageable pageable` 파라미터를 사용하는 컨트롤러에 자동으로 적용됨


### **🧑‍💻 작업 유형**

- [x]  새로운 기능 추가
- [x] 테스트코드 수정

### **🚨 주의 사항**

공통모듈 1.0.0, 1.0.1 모두 사용 가능합니다. 저는 페이징을 위해 1.0.1로 변경했습니다!

