### PR TITLE
refactor & feat: api 권한 설정, 상품예약내역 개인조회 api 추가, 상품예약내역 단건 조회 트러블슈팅

### DIFF
--- a/product-reservation-service/build.gradle
+++ b/product-reservation-service/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     // 공통 모듈
-    implementation 'com.github.wonsongleejo:common-module:1.0.1'
+    implementation 'com.github.wonsongleejo:common-module:1.0.4'
 
     // SpringDoc OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/dto/response/ResProductReservationGetByIdDTOApiV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/dto/response/ResProductReservationGetByIdDTOApiV1.java
@@ -77,6 +77,7 @@ public class ResProductReservationGetByIdDTOApiV1 {
             }
         }
 
+        // Store
         @Getter
         @Builder
         @NoArgsConstructor
@@ -93,6 +94,7 @@ public class ResProductReservationGetByIdDTOApiV1 {
             }
         }
 
+        // User
         @Getter
         @Builder
         @NoArgsConstructor

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/service/ProductReservationServiceApiV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/service/ProductReservationServiceApiV1.java
@@ -1,5 +1,7 @@
 package com.monkey.productreservationservice.application.service;
 
+import com.monkey.common_module.aop.AccessLevel;
+import com.monkey.common_module.aop.CheckUserRole;
 import com.monkey.common_module.dto.ResponseCode;
 import com.monkey.common_module.exception.CustomException;
 import com.monkey.productreservationservice.application.dto.request.ReqProductReservationPostDTOApiV1;
@@ -30,6 +32,7 @@ public class ProductReservationServiceApiV1 {
     private final ProductReservationReadValidator readValidator;
 
     // 예약 등록
+    @CheckUserRole(AccessLevel.USER)
     public ResProductReservationPostDTOApiV1 postBy(ReqProductReservationPostDTOApiV1 reqDto, UUID productId, long userId) {
         var product = reservationValidator.validateProduct(productId); // 유효한 상품 확인
 
@@ -50,6 +53,7 @@ public class ProductReservationServiceApiV1 {
     }
 
     // 예약 취소
+    @CheckUserRole(AccessLevel.USER)
     public ResProductReservationPostByIdCancelDTOApiV1 cancelBy(UUID productReservationId, long userId) {
         ProductReservationEntity productReservationEntity = getActiveProductReservationById(productReservationId);
         productReservationEntity.cancel(userId);
@@ -58,12 +62,14 @@ public class ProductReservationServiceApiV1 {
     }
 
     // 예약내역 전체 조회
+    @CheckUserRole(AccessLevel.ALL)
     public ResProductReservationGetDTOApiV1 getBy(Pageable pageable) {
         Page<ProductReservationEntity> productReservationPage = productReservationRepository.findAllByIsDeletedFalse(pageable);
         return ResProductReservationGetDTOApiV1.of(productReservationPage);
     }
 
     // 예약내역 단건 조회
+    @CheckUserRole(AccessLevel.ALL)
     public ResProductReservationGetByIdDTOApiV1 getById(UUID productReservationId) {
         ProductReservationEntity productReservation = getActiveProductReservationById(productReservationId);
 
@@ -75,6 +81,7 @@ public class ProductReservationServiceApiV1 {
     }
 
     // 개인 예약내역 조회
+    @CheckUserRole(AccessLevel.USER)
     public ResProductReservationGetDTOApiV1 getByUserId(long userId, Pageable pageable) {
         Page<ProductReservationEntity> productReservationPage =
                 productReservationRepository.findByUserIdAndIsDeletedFalse(userId, pageable);

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/service/ProductReservationServiceApiV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/service/ProductReservationServiceApiV1.java
@@ -74,6 +74,13 @@ public class ProductReservationServiceApiV1 {
         return ResProductReservationGetByIdDTOApiV1.of(productReservation, resProduct, resStore, resUser);
     }
 
+    // 개인 예약내역 조회
+    public ResProductReservationGetDTOApiV1 getByUserId(long userId, Pageable pageable) {
+        Page<ProductReservationEntity> productReservationPage =
+                productReservationRepository.findByUserIdAndIsDeletedFalse(userId, pageable);
+        return ResProductReservationGetDTOApiV1.of(productReservationPage);
+    }
+
     // 존재하는 예약 검증 메서드
     private ProductReservationEntity getActiveProductReservationById(UUID productReservationId) {
         return productReservationRepository.findByProductReservationIdAndIsDeletedFalse(productReservationId)

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/validator/ProductReservationReadValidator.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/validator/ProductReservationReadValidator.java
@@ -42,7 +42,6 @@ public class ProductReservationReadValidator {
     public ResStoreClientGetByIdDTOApiV1.Store validateStore(UUID storeId) {
         try {
             var storeRes = storeClient.getStoreById(storeId);
-//            var store = storeResponse != null ? storeResponse.getData() : null;
             var store = storeRes.getData() != null ? storeRes.getData().getStore() : null;
 
             if (store == null) throw new CustomException(ResponseCode.STORE_NOT_FOUND);

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/domain/repository/ProductReservationRepository.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/domain/repository/ProductReservationRepository.java
@@ -4,14 +4,13 @@ import com.monkey.productreservationservice.domain.entity.ProductReservationEnti
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface ProductReservationRepository {
     ProductReservationEntity save(ProductReservationEntity entity);
     Optional<ProductReservationEntity> findByProductReservationIdAndIsDeletedFalse(UUID productReservationId);
-    List<ProductReservationEntity> findAllByIsDeletedFalse();
     Page<ProductReservationEntity> findAllByIsDeletedFalse(Pageable pageable);
+    Page<ProductReservationEntity> findByUserIdAndIsDeletedFalse(long userId, Pageable pageable);
     boolean existsByUserIdAndProductIdAndIsDeletedFalse(long userId, UUID productId);
 }

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/feignclient/UserFeignClientApiV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/feignclient/UserFeignClientApiV1.java
@@ -5,7 +5,6 @@ import com.monkey.productreservationservice.infrastructure.feignclient.dto.respo
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(name = "user-service", path = "v1/users")

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/persistence/ProductReservationJpaRepository.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/persistence/ProductReservationJpaRepository.java
@@ -5,13 +5,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface ProductReservationJpaRepository extends JpaRepository<ProductReservationEntity, UUID> {
     Optional<ProductReservationEntity> findByProductReservationIdAndIsDeletedFalse(UUID productReservationId);
-    List<ProductReservationEntity> findAllByIsDeletedFalse();
     Page<ProductReservationEntity> findAllByIsDeletedFalse(Pageable pageable);
+    Page<ProductReservationEntity> findByUserIdAndIsDeletedFalse(long userId, Pageable pageable);
     boolean existsByUserIdAndProductIdAndIsDeletedFalse(long userId, UUID productId);
 }

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/persistence/ProductReservationRepositoryImpl.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/persistence/ProductReservationRepositoryImpl.java
@@ -27,14 +27,15 @@ public class ProductReservationRepositoryImpl implements ProductReservationRepos
     }
 
     @Override
-    public List<ProductReservationEntity> findAllByIsDeletedFalse() {
-        return productReservationJpaRepository.findAllByIsDeletedFalse();
-    }
-
-    @Override
     public Page<ProductReservationEntity> findAllByIsDeletedFalse(Pageable pageable) {
         return productReservationJpaRepository.findAllByIsDeletedFalse(pageable);
     }
+
+    @Override
+    public Page<ProductReservationEntity> findByUserIdAndIsDeletedFalse(long userId, Pageable pageable) {
+        return productReservationJpaRepository.findByUserIdAndIsDeletedFalse(userId, pageable);
+    }
+
 
     @Override
     public boolean existsByUserIdAndProductIdAndIsDeletedFalse(long userId, UUID productId) {

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/presentation/controller/ProductReservationControllerApiV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/presentation/controller/ProductReservationControllerApiV1.java
@@ -56,4 +56,16 @@ public class ProductReservationControllerApiV1 {
         ResProductReservationGetByIdDTOApiV1 resDto = productReservationService.getById(productReservationId);
         return new ResponseEntity<>(ResDTO.success(resDto), HttpStatus.OK);
     }
+
+    // 개인 예약내역 조회
+    @GetMapping("/my")
+    public ResponseEntity<ResDTO<ResProductReservationGetDTOApiV1>> getMyProductReservations(
+            @RequestHeader("X-User-Id") long userId,
+            Pageable pageable
+    ) {
+        ResProductReservationGetDTOApiV1 resDto = productReservationService.getByUserId(userId, pageable);
+        return new ResponseEntity<>(ResDTO.success(resDto), HttpStatus.OK);
+    }
+
+
 }

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/presentation/controller/ProductReservationControllerApiV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/presentation/controller/ProductReservationControllerApiV1.java
@@ -50,13 +50,6 @@ public class ProductReservationControllerApiV1 {
         return new ResponseEntity<>(ResDTO.success(resDto), HttpStatus.OK);
     }
 
-    // 예약내역 단건 조회
-    @GetMapping("/{productReservationId}")
-    public ResponseEntity<ResDTO<ResProductReservationGetByIdDTOApiV1>> getById(@PathVariable UUID productReservationId) {
-        ResProductReservationGetByIdDTOApiV1 resDto = productReservationService.getById(productReservationId);
-        return new ResponseEntity<>(ResDTO.success(resDto), HttpStatus.OK);
-    }
-
     // 개인 예약내역 조회
     @GetMapping("/my")
     public ResponseEntity<ResDTO<ResProductReservationGetDTOApiV1>> getMyProductReservations(
@@ -67,5 +60,10 @@ public class ProductReservationControllerApiV1 {
         return new ResponseEntity<>(ResDTO.success(resDto), HttpStatus.OK);
     }
 
-
+    // 예약내역 단건 조회
+    @GetMapping("/{productReservationId}")
+    public ResponseEntity<ResDTO<ResProductReservationGetByIdDTOApiV1>> getById(@PathVariable UUID productReservationId) {
+        ResProductReservationGetByIdDTOApiV1 resDto = productReservationService.getById(productReservationId);
+        return new ResponseEntity<>(ResDTO.success(resDto), HttpStatus.OK);
+    }
 }

--- a/product-reservation-service/src/test/java/com/monkey/productreservationservice/presentation/controller/ProductReservationControllerApiV1Test.java
+++ b/product-reservation-service/src/test/java/com/monkey/productreservationservice/presentation/controller/ProductReservationControllerApiV1Test.java
@@ -154,6 +154,7 @@ public class ProductReservationControllerApiV1Test {
         mockMvc.perform(
                 RestDocumentationRequestBuilders.post("/v1/product-reservations/{productId}", testProductId)
                         .header("X-User-Id", testUserId)
+                        .header("X-User-Role", "USER")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(reqDto))
                 )
@@ -203,6 +204,7 @@ public class ProductReservationControllerApiV1Test {
         mockMvc.perform(
                 RestDocumentationRequestBuilders.post("/v1/product-reservations/{productReservationId}/cancel", saved.getProductReservationId())
                         .header("X-User-Id", testUserId)
+                        .header("X-User-Role", "USER")
                         .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andExpectAll(

--- a/product-service/src/main/java/com/monkey/productservice/application/service/ProductServiceApiV1.java
+++ b/product-service/src/main/java/com/monkey/productservice/application/service/ProductServiceApiV1.java
@@ -1,5 +1,7 @@
 package com.monkey.productservice.application.service;
 
+import com.monkey.common_module.aop.AccessLevel;
+import com.monkey.common_module.aop.CheckUserRole;
 import com.monkey.common_module.dto.ResponseCode;
 import com.monkey.common_module.exception.CustomException;
 import com.monkey.productservice.application.dto.request.ReqProductPostDTOApiV1;
@@ -26,12 +28,14 @@ public class ProductServiceApiV1 {
     private final StoreFeignClientApiV1 storeClient;
 
     // 상품 등록
+    @CheckUserRole(AccessLevel.MANAGER)
     public ResProductPostDTOApiV1 postBy(ReqProductPostDTOApiV1 reqDto) {
         ProductEntity productEntity = reqDto.getProduct().toEntity();
         return ResProductPostDTOApiV1.of(productRepository.save(productEntity));
     }
 
     // 상품 수정
+    @CheckUserRole(AccessLevel.MANAGER)
     public ResProductPutDTOApiV1 putBy(UUID productId, ReqProductPutDTOApiV1 reqDto) {
         ProductEntity productEntity = getActiveProductById(productId);
 
@@ -42,12 +46,14 @@ public class ProductServiceApiV1 {
     }
 
     // 상품 전체 조회
+    @CheckUserRole(AccessLevel.ALL)
     public ResProductGetDTOApiV1 getBy(Pageable pageable) {
         Page<ProductEntity> productPage = productRepository.findAllByIsDeletedFalse(pageable);
         return ResProductGetDTOApiV1.of(productPage);
     }
 
     // 상품 단건 조회
+    @CheckUserRole(AccessLevel.ALL)
     public ResProductGetByIdDTOApiV1 getById(UUID productId) {
         ProductEntity product = getActiveProductById(productId);
 
@@ -62,6 +68,7 @@ public class ProductServiceApiV1 {
     }
 
     // 상품 삭제
+    @CheckUserRole(AccessLevel.MANAGER)
     public void deleteById(UUID productId, Long userId) {
         ProductEntity productEntity = getActiveProductById(productId);
         productEntity.delete(userId);

--- a/product-service/src/test/java/com/monkey/productservice/presentation/controller/ProductControllerApiV1Test.java
+++ b/product-service/src/test/java/com/monkey/productservice/presentation/controller/ProductControllerApiV1Test.java
@@ -81,8 +81,8 @@ public class ProductControllerApiV1Test {
 
         mockMvc.perform(
                         RestDocumentationRequestBuilders.post("/v1/products")
-//                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + resDto.getData().getAccessJwt())
                                 .header("X-User-Id", 123L)
+                                .header("X-User-Role", "MANAGER")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(reqDtoJson)
                 )
@@ -148,8 +148,8 @@ public class ProductControllerApiV1Test {
         String reqDtoJson = objectMapper.writeValueAsString(reqDto);
         mockMvc.perform(
                 RestDocumentationRequestBuilders.put("/v1/products/{productId}", saved.getProductId())
-//                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + resDto.getData().getAccessJwt())
                         .header("X-User-Id", 123L)
+                        .header("X-User-Role", "MANAGER")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(reqDtoJson)
                 )

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -9,7 +9,7 @@ ext {
 
 dependencies {
     // 공통 모듈
-    implementation 'com.github.wonsongleejo:common-module:1.0.0'
+    implementation 'com.github.wonsongleejo:common-module:1.0.4'
 
     // validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'


### PR DESCRIPTION
### **📌 작업 내용**

* @CheckRoleUser 를 통해 상품/상품예약 api별 권한 설정
* 상품예약내역 개인 조회용 api 추가: `v1/product-reservations/my`


### **🧑‍💻 작업 유형**

- [x]  새로운 기능 추가
- [x]  설정 변경
- [x]  테스트 수정


### **🚨 트러블슈팅**

- 상품예약내역 단건 조회에서 feignclient로 유저정보 호출 시 X-User-Name, X-User-Role 헤더가 전달되지 않아 JWTFilter에서 인증 실패 로그 발생

- 해결 방법: 공통 모듈에 아래 구성 추가:
  - AuthorizationHeaderAspect: 컨트롤러 진입 시 Authorization 헤더를 ThreadLocal에 저장
  - AuthorizationContextHolder: ThreadLocal 기반 토큰 저장
  - FeignAuthInterceptor: Feign 요청 시 Authorization + X-User-* 헤더 자동 주입
