### PR TITLE
refactor: 상품 예약내역 단건조회 응답에 유저의 slackId 추가

### DIFF
--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/dto/response/ResProductReservationGetByIdDTOApiV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/dto/response/ResProductReservationGetByIdDTOApiV1.java
@@ -102,11 +102,13 @@ public class ResProductReservationGetByIdDTOApiV1 {
         public static class User {
             private long userId;
             private String userName;
+            private String slackId;
 
             public static User from(ResUserClientGetByIdDTOApiV1.User userDto) {
                 return User.builder()
                         .userId(userDto.getUserId())
                         .userName(userDto.getUsername())
+                        .slackId(userDto.getSlackId())
                         .build();
             }
         }

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/feignclient/dto/response/ResUserClientGetByIdDTOApiV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/feignclient/dto/response/ResUserClientGetByIdDTOApiV1.java
@@ -19,5 +19,6 @@ public class ResUserClientGetByIdDTOApiV1 {
     public static class User {
         private Long userId;
         private String username;
+        private String slackId;
     }
 }

--- a/product-reservation-service/src/test/java/com/monkey/productreservationservice/presentation/controller/ProductReservationControllerApiV1Test.java
+++ b/product-reservation-service/src/test/java/com/monkey/productreservationservice/presentation/controller/ProductReservationControllerApiV1Test.java
@@ -74,6 +74,7 @@ public class ProductReservationControllerApiV1Test {
     private UUID testProductId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     private UUID testStoreId = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
     private long testUserId = 123L;
+    private String testSlackId = "cccccccc-cccc-cccc-cccc-cccccccccccc";
 
     @BeforeEach
     void setUpFeignClientMocks() {
@@ -139,6 +140,7 @@ public class ProductReservationControllerApiV1Test {
                                 .user(ResUserClientGetByIdDTOApiV1.User.builder()
                                         .userId(testUserId)
                                         .username("라이언")
+                                        .slackId(testSlackId)
                                         .build())
                                 .build()
                 ));
@@ -282,6 +284,7 @@ public class ProductReservationControllerApiV1Test {
 
                                                 fieldWithPath("data.productReservation.user.userId").type(JsonFieldType.NUMBER).description("유저 ID"),
                                                 fieldWithPath("data.productReservation.user.userName").type(JsonFieldType.STRING).description("유저 이름"),
+                                                fieldWithPath("data.productReservation.user.slackId").type(JsonFieldType.STRING).description("유저 슬랙 ID"),
 
                                                 fieldWithPath("data.productReservation.store.storeId").type(JsonFieldType.STRING).description("스토어 ID"),
                                                 fieldWithPath("data.productReservation.store.storeName").type(JsonFieldType.STRING).description("스토어 이름")


### PR DESCRIPTION
### **📌 작업 내용**
상품 예약내역 단건조회 응답에 유저의 slackId 추가

### **🧑‍💻 작업 유형**

- [x]  코드 리팩토링
- [x]  테스트 수정


### **🚨 주의 사항**

현재 dev 최신으로 반영한 후에 SlackClient 패키지 구조 에러로 인해 실행은 해보지 못했습니다. 근데 이전에 유저 feignClient 문제 해결하고 실행했을 땐 잘 됐으니까 아마 slackId도 잘 받아올 것 같습니다!

슬랙도메인 에러 해결되면 다시 실행해보고 문제 있으면 수정하겠습니다


<img width="1122" alt="스크린샷 2025-04-24 오전 11 43 21" src="https://github.com/user-attachments/assets/ae09de6e-ca57-4009-adf3-ed1b02d9d0b3" />
