### PR TITLE
feat: 예약 생성 시 정원 및 현재 예약 인원을 Redis로 캐싱

### DIFF
--- a/store-reservation-service/build.gradle
+++ b/store-reservation-service/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     testImplementation 'org.eclipse.jetty:jetty-webapp:9.4.51.v20230217'
     testImplementation 'org.eclipse.jetty:jetty-xml:9.4.51.v20230217'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV2.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV2.java
@@ -17,32 +17,55 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
-@Service("storeReservationServiceV1")
+@Service("storeReservationServiceV2")
 @Transactional
-public class StoreReservationServiceImplApiV1 implements StoreReservationServiceApiV1 {
+public class StoreReservationServiceImplApiV2 implements StoreReservationServiceApiV1 {
 
     private final StoreReservationRepository storeReservationRepository;
     private final StoreClient storeClient;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     private PersonInfo calculateCurrentAndMaxPerson(UUID timeSlotId) {
+        String currentKey = "timeslot:" + timeSlotId + ":currentReservedPerson";
+        String maxKey = "timeslot:" + timeSlotId + ":maxPerson";
 
-        Integer currentReservedPersonCount = storeReservationRepository.sumPersonCountByTimeSlotId(timeSlotId);
-        if (currentReservedPersonCount == null) {
-            currentReservedPersonCount = 0;
+        Integer currentReservedPerson = getValueFromRedis(currentKey);
+        Integer maxPerson = getValueFromRedis(maxKey);
+
+        if (currentReservedPerson == null) {
+            currentReservedPerson = 0;
         }
 
-        ResStoreTimeSlotDTOApiV1 timeSlotResponse = storeClient.getTimeSlotById(timeSlotId);
-        ResStoreTimeSlotDTOApiV1.StoreTimeSlot timeSlot = timeSlotResponse.getData().getStoreTimeSlot();
-        Integer maxPerson = timeSlot.getMaxPerson();
+        if (maxPerson == null) {
+            // 캐시에 없으면 Feign Client 호출
+            ResStoreTimeSlotDTOApiV1 timeSlotResponse = storeClient.getTimeSlotById(timeSlotId);
+            ResStoreTimeSlotDTOApiV1.StoreTimeSlot timeSlot = timeSlotResponse.getData().getStoreTimeSlot();
+            maxPerson = timeSlot.getMaxPerson();
 
-        return new PersonInfo(currentReservedPersonCount, maxPerson);
+            // Redis에 저장
+            redisTemplate.opsForValue().set(maxKey, maxPerson);
+        }
+
+        return new PersonInfo(currentReservedPerson, maxPerson);
+    }
+
+    private Integer getValueFromRedis(String key) {
+        Object value = redisTemplate.opsForValue().get(key);
+        return value != null ? Integer.parseInt(value.toString()) : null;
+    }
+
+    private void updateCurrentReservedPerson(UUID timeSlotId, int newCount) {
+        String currentKey = "timeslot:" + timeSlotId + ":currentReservedPerson";
+        redisTemplate.opsForValue().set(currentKey, newCount);
     }
 
     @Getter
@@ -71,6 +94,9 @@ public class StoreReservationServiceImplApiV1 implements StoreReservationService
         );
 
         StoreReservationEntity saved = storeReservationRepository.save(entity);
+
+        // Redis에 현재 예약 인원 업데이트
+        updateCurrentReservedPerson(timeSlotId, personInfo.getCurrentReservedPerson() + requestedPersonCount);
 
         return ResStoreReservationPostDTOApiV1.from(saved, personInfo.getCurrentReservedPerson() + requestedPersonCount, personInfo.getMaxPerson());
     }
@@ -153,23 +179,22 @@ public class StoreReservationServiceImplApiV1 implements StoreReservationService
         return ResStoreReservationPutByIdStatusDTOApiV1.from(saved, personInfo.getCurrentReservedPerson(), personInfo.getMaxPerson());
     }
 
-    // feignClient: 상품 예약 시 스토어 예약내역 전체 조회 -> 스토어 예약한 회원인지 확인
     @Override
     public ResStoreReservationGetDTOApiV1 getAllByUserIdAndStoreId(Long userId, UUID storeId) {
         List<ResStoreReservationGetDTOApiV1.StoreReservation> list = storeReservationRepository.findAll().stream()
-                .filter(res -> res.getUserId().equals(userId)) // userId 기준 필터링
+                .filter(res -> res.getUserId().equals(userId))
                 .map(entity -> {
                     try {
-                        ResStoreTimeSlotDTOApiV1 timeSlotResponse = storeClient.getTimeSlotById(entity.getTimeSlotId());
-                        if (timeSlotResponse == null || timeSlotResponse.getData() == null) {
-                            throw new RuntimeException("TimeSlot not found: " + entity.getTimeSlotId());
-                        }
+                        PersonInfo personInfo = calculateCurrentAndMaxPerson(entity.getTimeSlotId());
 
+                        ResStoreTimeSlotDTOApiV1 timeSlotResponse = storeClient.getTimeSlotById(entity.getTimeSlotId());
                         ResStoreTimeSlotDTOApiV1.StoreTimeSlot timeSlot = timeSlotResponse.getData().getStoreTimeSlot();
 
                         return ResStoreReservationGetDTOApiV1.StoreReservation.builder()
                                 .storeReservationId(entity.getStoreReservationId())
                                 .status(entity.getStatus())
+                                .currentReservedPerson(personInfo.getCurrentReservedPerson())
+                                .maxPerson(personInfo.getMaxPerson())
                                 .timeSlot(
                                         ResStoreReservationGetDTOApiV1.StoreReservation.TimeSlot.builder()
                                                 .store(
@@ -185,7 +210,7 @@ public class StoreReservationServiceImplApiV1 implements StoreReservationService
                                 .user(
                                         ResStoreReservationGetDTOApiV1.StoreReservation.User.builder()
                                                 .userId(userId)
-                                                .userName("unknown") // 필요시 FeignClient로 조회 가능
+                                                .userName("unknown")
                                                 .build()
                                 )
                                 .build();
@@ -193,12 +218,10 @@ public class StoreReservationServiceImplApiV1 implements StoreReservationService
                         return null;
                     }
                 })
-                .filter(res ->
-                        res != null &&
-                                res.getTimeSlot() != null &&
-                                res.getTimeSlot().getStore() != null &&
-                                res.getTimeSlot().getStore().getStoreId().equals(storeId)
-                )
+                .filter(res -> res != null
+                        && res.getTimeSlot() != null
+                        && res.getTimeSlot().getStore() != null
+                        && res.getTimeSlot().getStore().getStoreId().equals(storeId))
                 .toList();
 
         return ResStoreReservationGetDTOApiV1.builder()

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/infrastructure/config/RedisConfig.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/infrastructure/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package com.monkey.storereservationservice.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Object.class));
+        return template;
+    }
+}

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1.java
@@ -10,7 +10,7 @@ import com.monkey.storereservationservice.application.dto.response.ResStoreReser
 import com.monkey.storereservationservice.application.service.StoreReservationServiceApiV1;
 import com.monkey.storereservationservice.infrastructure.security.UserContext;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,11 +18,18 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/v1/store-reservations")
-@RequiredArgsConstructor
 public class StoreReservationControllerApiV1 {
 
     private final StoreReservationServiceApiV1 storeReservationServiceApiV1;
     private final UserContext userContext;
+
+    public StoreReservationControllerApiV1(
+            @Qualifier("storeReservationServiceV2") StoreReservationServiceApiV1 storeReservationServiceApiV1,
+            UserContext userContext
+    ) {
+        this.storeReservationServiceApiV1 = storeReservationServiceApiV1;
+        this.userContext = userContext;
+    }
 
     // 예약 생성
     @PostMapping

--- a/store-reservation-service/src/main/resources/application.yml
+++ b/store-reservation-service/src/main/resources/application.yml
@@ -18,6 +18,13 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
     show-sql: true
 
+  # Redis
+  data:
+    redis:
+      host: localhost
+      port: 6379
+#      password: systempass
+
 #  #  더미데이터용 환경설정 *배포시 삭제 필요*
 #  profiles:
 #    active: dev


### PR DESCRIPTION
### **📌 작업 내용**

- As-is
    - 시간대별 정원을 Feign Client로 호출
    - 현재 예약 인원을 DB에 저장된 personCount 계산
- To-be
    - 정원과 현재 예약 인원을 Redis로 캐싱하였습니다.

### **🧑‍💻 작업 유형**

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  코드 리팩토링
- [ ]  문서 수정
- [ ]  설정 변경
- [ ]  CI/CD 변경
- [ ]  테스트 추가
- [ ]  테스트 수정

### **📷 Jmeter로 테스트**

❌ Redis 적용 전 Jmeter Summary Report
![image](https://github.com/user-attachments/assets/a1bca2b5-cdbc-427e-8282-d048964e3ca6)

✅ Redis 적용 후 Jmeter Summary Report
![image](https://github.com/user-attachments/assets/0e09336c-d240-4416-981a-31fde8ed36ff)


Redis 적용 후 평균 응답시간은 약 **2.9배 감소**, 초당 처리량은 약 **2.8배 증가**했습니다.