### PR TITLE
feat: 상품 전체 조회에 Redis 캐싱 적용

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -40,7 +40,7 @@ spring:
             - AuthorizationHeaderFilter
           uri: lb://product-service
           predicates:
-            - Path=/v1/products/**, /springdoc/openapi3-product-service.json
+            - Path=/v1/products/**, /v2/products/**, /springdoc/openapi3-product-service.json
 
         # Product-reservation-service
         - id: product-reservation-service

--- a/product-reservation-service/src/main/resources/application.yml
+++ b/product-reservation-service/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     defer-datasource-initialization: true
     properties:
       hibernate:

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     implementation 'org.postgresql:postgresql:42.7.1'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 dependencyManagement {

--- a/product-service/src/main/java/com/monkey/productservice/application/service/v1/ProductServiceApiV1.java
+++ b/product-service/src/main/java/com/monkey/productservice/application/service/v1/ProductServiceApiV1.java
@@ -1,4 +1,4 @@
-package com.monkey.productservice.application.service;
+package com.monkey.productservice.application.service.v1;
 
 import com.monkey.common_module.aop.AccessLevel;
 import com.monkey.common_module.aop.CheckUserRole;

--- a/product-service/src/main/java/com/monkey/productservice/application/service/v2/ProductServiceApiV2.java
+++ b/product-service/src/main/java/com/monkey/productservice/application/service/v2/ProductServiceApiV2.java
@@ -1,0 +1,45 @@
+package com.monkey.productservice.application.service.v2;
+
+import com.monkey.common_module.aop.AccessLevel;
+import com.monkey.common_module.aop.CheckUserRole;
+import com.monkey.productservice.application.dto.response.ResProductGetDTOApiV1;
+import com.monkey.productservice.domain.entity.ProductEntity;
+import com.monkey.productservice.domain.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProductServiceApiV2 {
+    private final ProductRepository productRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @CheckUserRole(AccessLevel.ALL)
+    public ResProductGetDTOApiV1 getBy(Pageable pageable) {
+        String cacheKey = "products:page=" + pageable.getPageNumber() + "&size=" + pageable.getPageSize();
+
+        // 캐시 조회
+        ResProductGetDTOApiV1 cached = (ResProductGetDTOApiV1) redisTemplate.opsForValue().get(cacheKey);
+        if (cached != null) {
+            log.info("캐시 조회 성공. key={}", cacheKey);
+            return cached;
+        }
+
+        // 캐시 없으면 DB 조회
+        Page<ProductEntity> productPage = productRepository.findAllByIsDeletedFalse(pageable);
+        ResProductGetDTOApiV1 resDto = ResProductGetDTOApiV1.of(productPage);
+
+        // Redis 저장
+        redisTemplate.opsForValue().set(cacheKey, resDto, Duration.ofMinutes(3));
+        log.info("캐시 없음. 새로 저장. key={}", cacheKey);
+
+        return resDto;
+    }
+}

--- a/product-service/src/main/java/com/monkey/productservice/infrastructure/config/RedisConfig.java
+++ b/product-service/src/main/java/com/monkey/productservice/infrastructure/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package com.monkey.productservice.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/product-service/src/main/java/com/monkey/productservice/presentation/controller/v1/ProductControllerApiV1.java
+++ b/product-service/src/main/java/com/monkey/productservice/presentation/controller/v1/ProductControllerApiV1.java
@@ -1,4 +1,4 @@
-package com.monkey.productservice.presentation.controller;
+package com.monkey.productservice.presentation.controller.v1;
 
 import com.monkey.common_module.dto.ResDTO;
 import com.monkey.productservice.application.dto.request.ReqProductPostDTOApiV1;
@@ -7,7 +7,7 @@ import com.monkey.productservice.application.dto.response.ResProductGetByIdDTOAp
 import com.monkey.productservice.application.dto.response.ResProductGetDTOApiV1;
 import com.monkey.productservice.application.dto.response.ResProductPostDTOApiV1;
 import com.monkey.productservice.application.dto.response.ResProductPutDTOApiV1;
-import com.monkey.productservice.application.service.ProductServiceApiV1;
+import com.monkey.productservice.application.service.v1.ProductServiceApiV1;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;

--- a/product-service/src/main/java/com/monkey/productservice/presentation/controller/v2/ProductControllerApiV2.java
+++ b/product-service/src/main/java/com/monkey/productservice/presentation/controller/v2/ProductControllerApiV2.java
@@ -1,0 +1,27 @@
+package com.monkey.productservice.presentation.controller.v2;
+
+import com.monkey.common_module.dto.ResDTO;
+import com.monkey.productservice.application.dto.response.ResProductGetDTOApiV1;
+import com.monkey.productservice.application.service.v2.ProductServiceApiV2;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v2/products")
+@RequiredArgsConstructor
+@Slf4j
+public class ProductControllerApiV2 {
+    private final ProductServiceApiV2 productServiceApiV2;
+
+    @GetMapping
+    public ResponseEntity<ResDTO<ResProductGetDTOApiV1>> getBy(Pageable pageable) {
+        ResProductGetDTOApiV1 resDto = productServiceApiV2.getBy(pageable);
+        return new ResponseEntity<>(ResDTO.success(resDto), HttpStatus.OK);
+    }
+}

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -49,6 +49,7 @@ springdoc:
     - group: openapi3-product-service
       paths-to-match:
         - /v1/products/**
+        - /v2/products/**
       packages-to-scan:
         - com.monkey.productservice.presentation.controller
   api-docs:

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     defer-datasource-initialization: true
     properties:
       hibernate:

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -26,6 +26,12 @@ spring:
     access-token-expiration: ${ACCESS_TOKEN_EXPIRATION}
     refresh-token-expiration: ${REFRESH_TOKEN_EXPIRATION}
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+
 server:
   port: 8084
 

--- a/slack-service/src/main/resources/application.yml
+++ b/slack-service/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/store-service/src/main/resources/application.yml
+++ b/store-service/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
### **📌 작업 내용**

상품 전체 조회에 Redis 캐싱 적용

### **🧑‍💻 작업 유형**

- [x]  새로운 기능 추가
- [x]  설정 변경


### **🚨 주의 사항**

상품 데이터 저장을 위해 yml의 jpa.hibernate.ddl-auto를 update로 변경했습니다.