### PR TITLE
feat: 팝업스토어 예약 시 분산 락 적용

### DIFF
--- a/store-reservation-service/build.gradle
+++ b/store-reservation-service/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     testImplementation 'org.eclipse.jetty:jetty-xml:9.4.51.v20230217'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.24.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/request/ReqStoreReservationPostDTOApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/dto/request/ReqStoreReservationPostDTOApiV1.java
@@ -23,6 +23,8 @@ public class ReqStoreReservationPostDTOApiV1 {
         private UUID timeSlotId;
 
         @NotNull(message = "예약 인원 입력은 필수입니다.")
+        @jakarta.validation.constraints.Min(value = 1, message = "예약은 최소 1명부터 가능합니다.")
+        @jakarta.validation.constraints.Max(value = 4, message = "예약은 최대 4명까지 가능합니다.")
         private Integer personCount;
     }
 }

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV3.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV3.java
@@ -1,0 +1,270 @@
+package com.monkey.storereservationservice.application.service;
+
+import com.monkey.common_module.dto.ResponseCode;
+import com.monkey.common_module.exception.CustomException;
+import com.monkey.storereservationservice.application.dto.request.ReqStoreReservationPostDTOApiV1;
+import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetByIdDTOApiV1;
+import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetDTOApiV1;
+import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPostDTOApiV1;
+import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPutByIdStatusDTOApiV1;
+import com.monkey.storereservationservice.domain.storereservation.entity.StoreReservationEntity;
+import com.monkey.storereservationservice.domain.storereservation.repository.StoreReservationRepository;
+import com.monkey.storereservationservice.domain.storereservation.vo.StoreReservationStatus;
+import com.monkey.storereservationservice.infrastructure.client.StoreClient;
+import com.monkey.storereservationservice.infrastructure.dto.response.ResStoreTimeSlotDTOApiV1;
+import com.monkey.storereservationservice.infrastructure.security.UserContext;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service("storeReservationServiceV3")
+@Transactional
+public class StoreReservationServiceImplApiV3 implements StoreReservationServiceApiV1 {
+
+    private final StoreReservationRepository storeReservationRepository;
+    private final StoreClient storeClient;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedissonClient redissonClient;
+
+    private PersonInfo calculateCurrentAndMaxPerson(UUID timeSlotId) {
+        String currentKey = "timeslot:" + timeSlotId + ":currentReservedPerson";
+        String maxKey = "timeslot:" + timeSlotId + ":maxPerson";
+
+        Integer currentReservedPerson = getValueFromRedis(currentKey);
+        Integer maxPerson = getValueFromRedis(maxKey);
+
+        if (currentReservedPerson == null) {
+            currentReservedPerson = 0;
+        }
+
+        if (maxPerson == null) {
+            // 캐시에 없으면 Feign Client 호출
+            ResStoreTimeSlotDTOApiV1 timeSlotResponse = storeClient.getTimeSlotById(timeSlotId);
+            ResStoreTimeSlotDTOApiV1.StoreTimeSlot timeSlot = timeSlotResponse.getData().getStoreTimeSlot();
+            maxPerson = timeSlot.getMaxPerson();
+
+            // Redis에 저장
+            redisTemplate.opsForValue().set(maxKey, maxPerson);
+        }
+
+        return new PersonInfo(currentReservedPerson, maxPerson);
+    }
+
+    private Integer getValueFromRedis(String key) {
+        Object value = redisTemplate.opsForValue().get(key);
+        return value != null ? Integer.parseInt(value.toString()) : null;
+    }
+
+    private void updateCurrentReservedPerson(UUID timeSlotId, int newCount) {
+        String currentKey = "timeslot:" + timeSlotId + ":currentReservedPerson";
+        redisTemplate.opsForValue().set(currentKey, newCount);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class PersonInfo {
+        private Integer currentReservedPerson;
+        private Integer maxPerson;
+    }
+
+    @Override
+    public ResStoreReservationPostDTOApiV1 create(ReqStoreReservationPostDTOApiV1 request, UserContext userContext) {
+        UUID timeSlotId = request.getStoreReservation().getTimeSlotId();
+        String lockKey = "lock:storeReservation:" + timeSlotId;
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            if (lock.tryLock(10, 5, TimeUnit.SECONDS)) { // 모든 요청에 무조건 락 걸기
+                PersonInfo personInfo = calculateCurrentAndMaxPerson(timeSlotId);
+
+                Integer requestedPersonCount = request.getStoreReservation().getPersonCount();
+
+                if (personInfo.getCurrentReservedPerson() + requestedPersonCount > personInfo.getMaxPerson()) {
+                    throw new CustomException(ResponseCode.STORE_RESERVATION_FULL);
+                }
+
+                StoreReservationEntity entity = StoreReservationEntity.createStoreReservation(
+                        timeSlotId,
+                        userContext.getUserId(),
+                        requestedPersonCount,
+                        StoreReservationStatus.SCHEDULED
+                );
+
+                StoreReservationEntity saved = storeReservationRepository.save(entity);
+
+                updateCurrentReservedPerson(timeSlotId, personInfo.getCurrentReservedPerson() + requestedPersonCount);
+
+                return ResStoreReservationPostDTOApiV1.from(saved, personInfo.getCurrentReservedPerson() + requestedPersonCount, personInfo.getMaxPerson());
+            } else {
+                throw new CustomException(ResponseCode.STORE_RESERVATION_FULL); // 락 획득 실패
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Lock acquisition interrupted", e);
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+
+    // 실제 예약 처리 로직만 따로 뺀 메서드
+    private ResStoreReservationPostDTOApiV1 reserve(UUID timeSlotId, Integer requestedPersonCount, UserContext userContext, PersonInfo personInfo) {
+        if (personInfo.getCurrentReservedPerson() + requestedPersonCount > personInfo.getMaxPerson()) {
+            throw new CustomException(ResponseCode.STORE_RESERVATION_FULL);
+        }
+
+        StoreReservationEntity entity = StoreReservationEntity.createStoreReservation(
+                timeSlotId,
+                userContext.getUserId(),
+                requestedPersonCount,
+                StoreReservationStatus.SCHEDULED
+        );
+
+        StoreReservationEntity saved = storeReservationRepository.save(entity);
+
+        // Redis에 현재 예약 인원 업데이트
+        updateCurrentReservedPerson(timeSlotId, personInfo.getCurrentReservedPerson() + requestedPersonCount);
+
+        return ResStoreReservationPostDTOApiV1.from(saved, personInfo.getCurrentReservedPerson() + requestedPersonCount, personInfo.getMaxPerson());
+    }
+
+    @Override
+    public ResStoreReservationGetDTOApiV1 getAll(UserContext userContext, UUID storeId) {
+        List<ResStoreReservationGetDTOApiV1.StoreReservation> list = storeReservationRepository.findAll().stream()
+                .filter(res -> res.getUserId().equals(userContext.getUserId()))
+                .map(entity -> {
+                    PersonInfo personInfo = calculateCurrentAndMaxPerson(entity.getTimeSlotId());
+
+                    ResStoreTimeSlotDTOApiV1 timeSlotResponse = storeClient.getTimeSlotById(entity.getTimeSlotId());
+                    ResStoreTimeSlotDTOApiV1.StoreTimeSlot timeSlot = timeSlotResponse.getData().getStoreTimeSlot();
+
+                    return ResStoreReservationGetDTOApiV1.StoreReservation.builder()
+                            .storeReservationId(entity.getStoreReservationId())
+                            .status(entity.getStatus())
+                            .currentReservedPerson(personInfo.getCurrentReservedPerson())
+                            .maxPerson(personInfo.getMaxPerson())
+                            .timeSlot(ResStoreReservationGetDTOApiV1.StoreReservation.TimeSlot.builder()
+                                    .store(ResStoreReservationGetDTOApiV1.StoreReservation.TimeSlot.Store.builder()
+                                            .storeId(timeSlot.getStoreId())
+                                            .build())
+                                    .date(timeSlot.getSlotDate())
+                                    .entryTime(timeSlot.getEntryTime())
+                                    .exitTime(timeSlot.getExitTime())
+                                    .build())
+                            .user(ResStoreReservationGetDTOApiV1.StoreReservation.User.builder()
+                                    .userId(userContext.getUserId())
+                                    .userName(userContext.getUserName())
+                                    .build())
+                            .build();
+                }).toList();
+
+        return ResStoreReservationGetDTOApiV1.builder()
+                .storeReservationList(list)
+                .build();
+    }
+
+    @Override
+    public ResStoreReservationGetByIdDTOApiV1 getById(UserContext userContext, UUID storeReservationId) {
+        StoreReservationEntity entity = storeReservationRepository.findById(storeReservationId);
+        PersonInfo personInfo = calculateCurrentAndMaxPerson(entity.getTimeSlotId());
+
+        ResStoreTimeSlotDTOApiV1 timeSlotResponse = storeClient.getTimeSlotById(entity.getTimeSlotId());
+        ResStoreTimeSlotDTOApiV1.StoreTimeSlot timeSlot = timeSlotResponse.getData().getStoreTimeSlot();
+
+        return ResStoreReservationGetByIdDTOApiV1.builder()
+                .storeReservation(ResStoreReservationGetByIdDTOApiV1.StoreReservation.builder()
+                        .storeReservationId(entity.getStoreReservationId())
+                        .status(entity.getStatus())
+                        .currentReservedPerson(personInfo.getCurrentReservedPerson())
+                        .maxPerson(personInfo.getMaxPerson())
+                        .timeSlot(ResStoreReservationGetByIdDTOApiV1.StoreReservation.TimeSlot.builder()
+                                .store(ResStoreReservationGetByIdDTOApiV1.StoreReservation.TimeSlot.Store.builder()
+                                        .storeId(timeSlot.getStoreId())
+                                        .build())
+                                .date(timeSlot.getSlotDate())
+                                .entryTime(timeSlot.getEntryTime())
+                                .exitTime(timeSlot.getExitTime())
+                                .build())
+                        .user(ResStoreReservationGetByIdDTOApiV1.StoreReservation.User.builder()
+                                .userId(userContext.getUserId())
+                                .userName(userContext.getUserName())
+                                .build())
+                        .build())
+                .build();
+    }
+
+    @Override
+    public ResStoreReservationPutByIdStatusDTOApiV1 changeStatus(UserContext userContext, UUID storeReservationId, StoreReservationStatus status) {
+        StoreReservationEntity entity = storeReservationRepository.findById(storeReservationId);
+        if (entity == null) throw new CustomException(ResponseCode.NOT_FOUND);
+
+        entity.changeStatus(status);
+        StoreReservationEntity saved = storeReservationRepository.save(entity);
+
+        PersonInfo personInfo = calculateCurrentAndMaxPerson(saved.getTimeSlotId());
+
+        return ResStoreReservationPutByIdStatusDTOApiV1.from(saved, personInfo.getCurrentReservedPerson(), personInfo.getMaxPerson());
+    }
+
+    @Override
+    public ResStoreReservationGetDTOApiV1 getAllByUserIdAndStoreId(Long userId, UUID storeId) {
+        List<ResStoreReservationGetDTOApiV1.StoreReservation> list = storeReservationRepository.findAll().stream()
+                .filter(res -> res.getUserId().equals(userId))
+                .map(entity -> {
+                    try {
+                        PersonInfo personInfo = calculateCurrentAndMaxPerson(entity.getTimeSlotId());
+
+                        ResStoreTimeSlotDTOApiV1 timeSlotResponse = storeClient.getTimeSlotById(entity.getTimeSlotId());
+                        ResStoreTimeSlotDTOApiV1.StoreTimeSlot timeSlot = timeSlotResponse.getData().getStoreTimeSlot();
+
+                        return ResStoreReservationGetDTOApiV1.StoreReservation.builder()
+                                .storeReservationId(entity.getStoreReservationId())
+                                .status(entity.getStatus())
+                                .currentReservedPerson(personInfo.getCurrentReservedPerson())
+                                .maxPerson(personInfo.getMaxPerson())
+                                .timeSlot(
+                                        ResStoreReservationGetDTOApiV1.StoreReservation.TimeSlot.builder()
+                                                .store(
+                                                        ResStoreReservationGetDTOApiV1.StoreReservation.TimeSlot.Store.builder()
+                                                                .storeId(timeSlot.getStoreId())
+                                                                .build()
+                                                )
+                                                .date(timeSlot.getSlotDate())
+                                                .entryTime(timeSlot.getEntryTime())
+                                                .exitTime(timeSlot.getExitTime())
+                                                .build()
+                                )
+                                .user(
+                                        ResStoreReservationGetDTOApiV1.StoreReservation.User.builder()
+                                                .userId(userId)
+                                                .userName("unknown")
+                                                .build()
+                                )
+                                .build();
+                    } catch (Exception e) {
+                        return null;
+                    }
+                })
+                .filter(res -> res != null
+                        && res.getTimeSlot() != null
+                        && res.getTimeSlot().getStore() != null
+                        && res.getTimeSlot().getStore().getStoreId().equals(storeId))
+                .toList();
+
+        return ResStoreReservationGetDTOApiV1.builder()
+                .storeReservationList(list)
+                .build();
+    }
+}

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV4.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV4.java
@@ -1,0 +1,263 @@
+package com.monkey.storereservationservice.application.service;
+
+import com.monkey.common_module.dto.ResponseCode;
+import com.monkey.common_module.exception.CustomException;
+import com.monkey.storereservationservice.application.dto.request.ReqStoreReservationPostDTOApiV1;
+import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetByIdDTOApiV1;
+import com.monkey.storereservationservice.application.dto.response.ResStoreReservationGetDTOApiV1;
+import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPostDTOApiV1;
+import com.monkey.storereservationservice.application.dto.response.ResStoreReservationPutByIdStatusDTOApiV1;
+import com.monkey.storereservationservice.domain.storereservation.entity.StoreReservationEntity;
+import com.monkey.storereservationservice.domain.storereservation.repository.StoreReservationRepository;
+import com.monkey.storereservationservice.domain.storereservation.vo.StoreReservationStatus;
+import com.monkey.storereservationservice.infrastructure.client.StoreClient;
+import com.monkey.storereservationservice.infrastructure.dto.response.ResStoreTimeSlotDTOApiV1;
+import com.monkey.storereservationservice.infrastructure.security.UserContext;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service("storeReservationServiceV4")
+@Transactional
+public class StoreReservationServiceImplApiV4 implements StoreReservationServiceApiV1 {
+
+    private final StoreReservationRepository storeReservationRepository;
+    private final StoreClient storeClient;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedissonClient redissonClient;
+
+    private PersonInfo calculateCurrentAndMaxPerson(UUID timeSlotId) {
+        String currentKey = "timeslot:" + timeSlotId + ":currentReservedPerson";
+        String maxKey = "timeslot:" + timeSlotId + ":maxPerson";
+
+        Integer currentReservedPerson = getValueFromRedis(currentKey);
+        Integer maxPerson = getValueFromRedis(maxKey);
+
+        if (currentReservedPerson == null) {
+            currentReservedPerson = 0;
+        }
+
+        if (maxPerson == null) {
+            // 캐시에 없으면 Feign Client 호출
+            ResStoreTimeSlotDTOApiV1 timeSlotResponse = storeClient.getTimeSlotById(timeSlotId);
+            ResStoreTimeSlotDTOApiV1.StoreTimeSlot timeSlot = timeSlotResponse.getData().getStoreTimeSlot();
+            maxPerson = timeSlot.getMaxPerson();
+
+            // Redis에 저장
+            redisTemplate.opsForValue().set(maxKey, maxPerson);
+        }
+
+        return new PersonInfo(currentReservedPerson, maxPerson);
+    }
+
+    private Integer getValueFromRedis(String key) {
+        Object value = redisTemplate.opsForValue().get(key);
+        return value != null ? Integer.parseInt(value.toString()) : null;
+    }
+
+    private void updateCurrentReservedPerson(UUID timeSlotId, int newCount) {
+        String currentKey = "timeslot:" + timeSlotId + ":currentReservedPerson";
+        redisTemplate.opsForValue().set(currentKey, newCount);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    private static class PersonInfo {
+        private Integer currentReservedPerson;
+        private Integer maxPerson;
+    }
+
+    @Override
+    public ResStoreReservationPostDTOApiV1 create(ReqStoreReservationPostDTOApiV1 request, UserContext userContext) {
+        UUID timeSlotId = request.getStoreReservation().getTimeSlotId();
+        PersonInfo personInfo = calculateCurrentAndMaxPerson(timeSlotId);
+
+        Integer requestedPersonCount = request.getStoreReservation().getPersonCount();
+
+        int remainingSeats = personInfo.getMaxPerson() - personInfo.getCurrentReservedPerson();
+
+        if (remainingSeats <= 4) {
+            // 4명 이하로 남으면 락 걸기
+            String lockKey = "lock:storeReservation:" + timeSlotId;
+            RLock lock = redissonClient.getLock(lockKey);
+
+            try {
+                if (lock.tryLock(10, 5, TimeUnit.SECONDS)) {
+                    return reserve(timeSlotId, requestedPersonCount, userContext, personInfo);
+                } else {
+                    throw new CustomException(ResponseCode.STORE_RESERVATION_FULL);
+                }
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Lock acquisition interrupted", e);
+            } finally {
+                if (lock.isHeldByCurrentThread()) {
+                    lock.unlock();
+                }
+            }
+        } else {
+            // 5명 이상 자리가 남아있으면 락 없이 바로 예약
+            return reserve(timeSlotId, requestedPersonCount, userContext, personInfo);
+        }
+    }
+
+    // 실제 예약 처리 로직만 따로 뺀 메서드
+    private ResStoreReservationPostDTOApiV1 reserve(UUID timeSlotId, Integer requestedPersonCount, UserContext userContext, PersonInfo personInfo) {
+        if (personInfo.getCurrentReservedPerson() + requestedPersonCount > personInfo.getMaxPerson()) {
+            throw new CustomException(ResponseCode.STORE_RESERVATION_FULL);
+        }
+
+        StoreReservationEntity entity = StoreReservationEntity.createStoreReservation(
+                timeSlotId,
+                userContext.getUserId(),
+                requestedPersonCount,
+                StoreReservationStatus.SCHEDULED
+        );
+
+        StoreReservationEntity saved = storeReservationRepository.save(entity);
+
+        // Redis에 현재 예약 인원 업데이트
+        updateCurrentReservedPerson(timeSlotId, personInfo.getCurrentReservedPerson() + requestedPersonCount);
+
+        return ResStoreReservationPostDTOApiV1.from(saved, personInfo.getCurrentReservedPerson() + requestedPersonCount, personInfo.getMaxPerson());
+    }
+
+    @Override
+    public ResStoreReservationGetDTOApiV1 getAll(UserContext userContext, UUID storeId) {
+        List<ResStoreReservationGetDTOApiV1.StoreReservation> list = storeReservationRepository.findAll().stream()
+                .filter(res -> res.getUserId().equals(userContext.getUserId()))
+                .map(entity -> {
+                    PersonInfo personInfo = calculateCurrentAndMaxPerson(entity.getTimeSlotId());
+
+                    ResStoreTimeSlotDTOApiV1 timeSlotResponse = storeClient.getTimeSlotById(entity.getTimeSlotId());
+                    ResStoreTimeSlotDTOApiV1.StoreTimeSlot timeSlot = timeSlotResponse.getData().getStoreTimeSlot();
+
+                    return ResStoreReservationGetDTOApiV1.StoreReservation.builder()
+                            .storeReservationId(entity.getStoreReservationId())
+                            .status(entity.getStatus())
+                            .currentReservedPerson(personInfo.getCurrentReservedPerson())
+                            .maxPerson(personInfo.getMaxPerson())
+                            .timeSlot(ResStoreReservationGetDTOApiV1.StoreReservation.TimeSlot.builder()
+                                    .store(ResStoreReservationGetDTOApiV1.StoreReservation.TimeSlot.Store.builder()
+                                            .storeId(timeSlot.getStoreId())
+                                            .build())
+                                    .date(timeSlot.getSlotDate())
+                                    .entryTime(timeSlot.getEntryTime())
+                                    .exitTime(timeSlot.getExitTime())
+                                    .build())
+                            .user(ResStoreReservationGetDTOApiV1.StoreReservation.User.builder()
+                                    .userId(userContext.getUserId())
+                                    .userName(userContext.getUserName())
+                                    .build())
+                            .build();
+                }).toList();
+
+        return ResStoreReservationGetDTOApiV1.builder()
+                .storeReservationList(list)
+                .build();
+    }
+
+    @Override
+    public ResStoreReservationGetByIdDTOApiV1 getById(UserContext userContext, UUID storeReservationId) {
+        StoreReservationEntity entity = storeReservationRepository.findById(storeReservationId);
+        PersonInfo personInfo = calculateCurrentAndMaxPerson(entity.getTimeSlotId());
+
+        ResStoreTimeSlotDTOApiV1 timeSlotResponse = storeClient.getTimeSlotById(entity.getTimeSlotId());
+        ResStoreTimeSlotDTOApiV1.StoreTimeSlot timeSlot = timeSlotResponse.getData().getStoreTimeSlot();
+
+        return ResStoreReservationGetByIdDTOApiV1.builder()
+                .storeReservation(ResStoreReservationGetByIdDTOApiV1.StoreReservation.builder()
+                        .storeReservationId(entity.getStoreReservationId())
+                        .status(entity.getStatus())
+                        .currentReservedPerson(personInfo.getCurrentReservedPerson())
+                        .maxPerson(personInfo.getMaxPerson())
+                        .timeSlot(ResStoreReservationGetByIdDTOApiV1.StoreReservation.TimeSlot.builder()
+                                .store(ResStoreReservationGetByIdDTOApiV1.StoreReservation.TimeSlot.Store.builder()
+                                        .storeId(timeSlot.getStoreId())
+                                        .build())
+                                .date(timeSlot.getSlotDate())
+                                .entryTime(timeSlot.getEntryTime())
+                                .exitTime(timeSlot.getExitTime())
+                                .build())
+                        .user(ResStoreReservationGetByIdDTOApiV1.StoreReservation.User.builder()
+                                .userId(userContext.getUserId())
+                                .userName(userContext.getUserName())
+                                .build())
+                        .build())
+                .build();
+    }
+
+    @Override
+    public ResStoreReservationPutByIdStatusDTOApiV1 changeStatus(UserContext userContext, UUID storeReservationId, StoreReservationStatus status) {
+        StoreReservationEntity entity = storeReservationRepository.findById(storeReservationId);
+        if (entity == null) throw new CustomException(ResponseCode.NOT_FOUND);
+
+        entity.changeStatus(status);
+        StoreReservationEntity saved = storeReservationRepository.save(entity);
+
+        PersonInfo personInfo = calculateCurrentAndMaxPerson(saved.getTimeSlotId());
+
+        return ResStoreReservationPutByIdStatusDTOApiV1.from(saved, personInfo.getCurrentReservedPerson(), personInfo.getMaxPerson());
+    }
+
+    @Override
+    public ResStoreReservationGetDTOApiV1 getAllByUserIdAndStoreId(Long userId, UUID storeId) {
+        List<ResStoreReservationGetDTOApiV1.StoreReservation> list = storeReservationRepository.findAll().stream()
+                .filter(res -> res.getUserId().equals(userId))
+                .map(entity -> {
+                    try {
+                        PersonInfo personInfo = calculateCurrentAndMaxPerson(entity.getTimeSlotId());
+
+                        ResStoreTimeSlotDTOApiV1 timeSlotResponse = storeClient.getTimeSlotById(entity.getTimeSlotId());
+                        ResStoreTimeSlotDTOApiV1.StoreTimeSlot timeSlot = timeSlotResponse.getData().getStoreTimeSlot();
+
+                        return ResStoreReservationGetDTOApiV1.StoreReservation.builder()
+                                .storeReservationId(entity.getStoreReservationId())
+                                .status(entity.getStatus())
+                                .currentReservedPerson(personInfo.getCurrentReservedPerson())
+                                .maxPerson(personInfo.getMaxPerson())
+                                .timeSlot(
+                                        ResStoreReservationGetDTOApiV1.StoreReservation.TimeSlot.builder()
+                                                .store(
+                                                        ResStoreReservationGetDTOApiV1.StoreReservation.TimeSlot.Store.builder()
+                                                                .storeId(timeSlot.getStoreId())
+                                                                .build()
+                                                )
+                                                .date(timeSlot.getSlotDate())
+                                                .entryTime(timeSlot.getEntryTime())
+                                                .exitTime(timeSlot.getExitTime())
+                                                .build()
+                                )
+                                .user(
+                                        ResStoreReservationGetDTOApiV1.StoreReservation.User.builder()
+                                                .userId(userId)
+                                                .userName("unknown")
+                                                .build()
+                                )
+                                .build();
+                    } catch (Exception e) {
+                        return null;
+                    }
+                })
+                .filter(res -> res != null
+                        && res.getTimeSlot() != null
+                        && res.getTimeSlot().getStore() != null
+                        && res.getTimeSlot().getStore().getStoreId().equals(storeId))
+                .toList();
+
+        return ResStoreReservationGetDTOApiV1.builder()
+                .storeReservationList(list)
+                .build();
+    }
+}

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1.java
@@ -24,7 +24,7 @@ public class StoreReservationControllerApiV1 {
     private final UserContext userContext;
 
     public StoreReservationControllerApiV1(
-            @Qualifier("storeReservationServiceV2") StoreReservationServiceApiV1 storeReservationServiceApiV1,
+            @Qualifier("storeReservationServiceV4") StoreReservationServiceApiV1 storeReservationServiceApiV1,
             UserContext userContext
     ) {
         this.storeReservationServiceApiV1 = storeReservationServiceApiV1;

--- a/store-reservation-service/src/main/resources/application.yml
+++ b/store-reservation-service/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
     redis:
       host: localhost
       port: 6379
-#      password: systempass
+      password: systempass
 
 #  #  더미데이터용 환경설정 *배포시 삭제 필요*
 #  profiles:


### PR DESCRIPTION
### **📌 작업 내용**

- As-is
    - 서비스 V1 : 기본 DB 저장 방식
    - 서비스 V2 : Redis 캐싱만 적용
- To-be
    - 서비스 V3 : **모든** 예약 생성 요청에 Reddison Lock 적용
    - 서비스 V4 : 정원 **마감 임박** 시(4명 이하)에만 Reddison Lock 적용
        - Lock 적용을 위해 최대 예약 가능 인원 수를 **4명**으로 제한하였습니다.

### **🧑‍💻 작업 유형**

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  코드 리팩토링
- [ ]  문서 수정
- [ ]  설정 변경
- [ ]  CI/CD 변경
- [ ]  테스트 추가
- [ ]  테스트 수정

### **📷 Jmeter로 테스트**

✅ **모든** 예약 생성 요청에 Redisson Lock 적용 후 Jmeter Summary Report
![image](https://github.com/user-attachments/assets/e7d9f0d3-dacd-4d65-a5e6-f30d6f2b2ab7)

✅ 정원 **마감 임박** 시에만 Redisson Lock 적용 후 Jmeter Summary Report
![image](https://github.com/user-attachments/assets/ae8c7a80-af84-4651-ac54-714ba42b91d8)

- **모든** 요청에 Lock을 거는 방식(V3)은 동시성은 안전하지만 성능이 크게 저하됩니다.
- 정원 **마감 임박** 시에만 Lock을 거는 방식(V4)은 동시성 안전성과 성능을 모두 어느 정도 확보할 수 있었습니다.
<br>

### **📝 결론**

JMeter 성능 테스트 결과를 기준으로 **정원 임박 시에만 Lock(V4)** 방식이 실서비스 환경에 더 적합할 것으로 판단하고 있습니다.
<br>