### PR TITLE
feat: 예약 취소 시 현재 예약 인원 수 변경하는 로직 추가

### DIFF
--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV1.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV1.java
@@ -143,14 +143,28 @@ public class StoreReservationServiceImplApiV1 implements StoreReservationService
     @Override
     public ResStoreReservationPutByIdStatusDTOApiV1 changeStatus(UserContext userContext, UUID storeReservationId, StoreReservationStatus status) {
         StoreReservationEntity entity = storeReservationRepository.findById(storeReservationId);
-        if (entity == null) throw new CustomException(ResponseCode.NOT_FOUND);
+        if (entity == null) {
+            throw new CustomException(ResponseCode.NOT_FOUND);
+        }
 
         entity.changeStatus(status);
         StoreReservationEntity saved = storeReservationRepository.save(entity);
 
-        PersonInfo personInfo = calculateCurrentAndMaxPerson(saved.getTimeSlotId());
+        ResStoreTimeSlotDTOApiV1 timeSlotResponse = storeClient.getTimeSlotById(saved.getTimeSlotId());
+        ResStoreTimeSlotDTOApiV1.StoreTimeSlot timeSlot = timeSlotResponse.getData().getStoreTimeSlot();
 
-        return ResStoreReservationPutByIdStatusDTOApiV1.from(saved, personInfo.getCurrentReservedPerson(), personInfo.getMaxPerson());
+        Integer maxPerson = timeSlot.getMaxPerson();
+
+        // DB 조회로 현재 예약된 인원 수 계산
+        int currentReservedPerson = storeReservationRepository
+                .findAll()
+                .stream()
+                .filter(res -> res.getTimeSlotId().equals(saved.getTimeSlotId()))
+                .filter(res -> res.getStatus() == StoreReservationStatus.SCHEDULED)
+                .mapToInt(StoreReservationEntity::getPersonCount)
+                .sum();
+
+        return ResStoreReservationPutByIdStatusDTOApiV1.from(saved, currentReservedPerson, maxPerson);
     }
 
     // feignClient: 상품 예약 시 스토어 예약내역 전체 조회 -> 스토어 예약한 회원인지 확인

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV2.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV2.java
@@ -171,12 +171,30 @@ public class StoreReservationServiceImplApiV2 implements StoreReservationService
         StoreReservationEntity entity = storeReservationRepository.findById(storeReservationId);
         if (entity == null) throw new CustomException(ResponseCode.NOT_FOUND);
 
+        // 예약 취소되면 예약 인원 수만큼 currentReservedPerson 감소
+        if (status == StoreReservationStatus.CANCELED && entity.getStatus() != StoreReservationStatus.CANCELED) {
+            int decreaseCount = entity.getPersonCount();
+            decreaseCurrentReservedPerson(entity.getTimeSlotId(), decreaseCount);
+        }
+
         entity.changeStatus(status);
         StoreReservationEntity saved = storeReservationRepository.save(entity);
 
         PersonInfo personInfo = calculateCurrentAndMaxPerson(saved.getTimeSlotId());
 
         return ResStoreReservationPutByIdStatusDTOApiV1.from(saved, personInfo.getCurrentReservedPerson(), personInfo.getMaxPerson());
+    }
+
+    private void decreaseCurrentReservedPerson(UUID timeSlotId, int decreaseCount) {
+        String currentKey = "timeslot:" + timeSlotId + ":currentReservedPerson";
+        Integer currentReservedPerson = getValueFromRedis(currentKey);
+
+        if (currentReservedPerson == null) {
+            currentReservedPerson = 0;
+        }
+
+        int newCount = Math.max(0, currentReservedPerson - decreaseCount);
+        redisTemplate.opsForValue().set(currentKey, newCount);
     }
 
     @Override

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV3.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV3.java
@@ -210,12 +210,30 @@ public class StoreReservationServiceImplApiV3 implements StoreReservationService
         StoreReservationEntity entity = storeReservationRepository.findById(storeReservationId);
         if (entity == null) throw new CustomException(ResponseCode.NOT_FOUND);
 
+        // 예약 취소되면 예약 인원 수만큼 currentReservedPerson 감소
+        if (status == StoreReservationStatus.CANCELED && entity.getStatus() != StoreReservationStatus.CANCELED) {
+            int decreaseCount = entity.getPersonCount();
+            decreaseCurrentReservedPerson(entity.getTimeSlotId(), decreaseCount);
+        }
+
         entity.changeStatus(status);
         StoreReservationEntity saved = storeReservationRepository.save(entity);
 
         PersonInfo personInfo = calculateCurrentAndMaxPerson(saved.getTimeSlotId());
 
         return ResStoreReservationPutByIdStatusDTOApiV1.from(saved, personInfo.getCurrentReservedPerson(), personInfo.getMaxPerson());
+    }
+
+    private void decreaseCurrentReservedPerson(UUID timeSlotId, int decreaseCount) {
+        String currentKey = "timeslot:" + timeSlotId + ":currentReservedPerson";
+        Integer currentReservedPerson = getValueFromRedis(currentKey);
+
+        if (currentReservedPerson == null) {
+            currentReservedPerson = 0;
+        }
+
+        int newCount = Math.max(0, currentReservedPerson - decreaseCount);
+        redisTemplate.opsForValue().set(currentKey, newCount);
     }
 
     @Override

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV4.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV4.java
@@ -203,12 +203,30 @@ public class StoreReservationServiceImplApiV4 implements StoreReservationService
         StoreReservationEntity entity = storeReservationRepository.findById(storeReservationId);
         if (entity == null) throw new CustomException(ResponseCode.NOT_FOUND);
 
+        // 예약 취소되면 예약 인원 수만큼 currentReservedPerson 감소
+        if (status == StoreReservationStatus.CANCELED && entity.getStatus() != StoreReservationStatus.CANCELED) {
+            int decreaseCount = entity.getPersonCount();
+            decreaseCurrentReservedPerson(entity.getTimeSlotId(), decreaseCount);
+        }
+
         entity.changeStatus(status);
         StoreReservationEntity saved = storeReservationRepository.save(entity);
 
         PersonInfo personInfo = calculateCurrentAndMaxPerson(saved.getTimeSlotId());
 
         return ResStoreReservationPutByIdStatusDTOApiV1.from(saved, personInfo.getCurrentReservedPerson(), personInfo.getMaxPerson());
+    }
+
+    private void decreaseCurrentReservedPerson(UUID timeSlotId, int decreaseCount) {
+        String currentKey = "timeslot:" + timeSlotId + ":currentReservedPerson";
+        Integer currentReservedPerson = getValueFromRedis(currentKey);
+
+        if (currentReservedPerson == null) {
+            currentReservedPerson = 0;
+        }
+
+        int newCount = Math.max(0, currentReservedPerson - decreaseCount);
+        redisTemplate.opsForValue().set(currentKey, newCount);
     }
 
     @Override


### PR DESCRIPTION
### **📌 작업 내용**

- As-is
    - 예약 취소 시 현재 예약 인원 수에 반영되지 않았었습니다.
- To-be
    - Redis를 사용하지 않는 기본 서비스(V1)에서는 DB 조회를 통해 currentReservedPerson을 계산
    - V2, V3, V4 에서는 Redis 캐싱으로 현재 예약된 인원 수를 계산

### **🧑‍💻 작업 유형**

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  코드 리팩토링
- [ ]  문서 수정
- [ ]  설정 변경
- [ ]  CI/CD 변경
- [ ]  테스트 추가
- [ ]  테스트 수정