### PR TITLE
feat: 상품 예약 api에 Redisson 기반 분산 락 적용

### DIFF
--- a/product-reservation-service/build.gradle
+++ b/product-reservation-service/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     // 공통 모듈
-    implementation 'com.github.wonsongleejo:common-module:1.0.4'
+    implementation 'com.github.wonsongleejo:common-module:1.0.5'
 
     // SpringDoc OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/service/v1/ProductReservationServiceApiV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/service/v1/ProductReservationServiceApiV1.java
@@ -4,6 +4,7 @@ import com.monkey.common_module.aop.AccessLevel;
 import com.monkey.common_module.aop.CheckUserRole;
 import com.monkey.common_module.dto.ResponseCode;
 import com.monkey.common_module.exception.CustomException;
+import com.monkey.common_module.lock.DistributedLock;
 import com.monkey.productreservationservice.application.dto.request.ReqProductReservationPostDTOApiV1;
 import com.monkey.productreservationservice.application.dto.response.ResProductReservationGetByIdDTOApiV1;
 import com.monkey.productreservationservice.application.dto.response.ResProductReservationGetDTOApiV1;
@@ -37,6 +38,7 @@ public class ProductReservationServiceApiV1 {
 
     // 예약 등록
     @CheckUserRole(AccessLevel.USER)
+    @DistributedLock(key = "'product:' + #productId", waitTime = 10, leaseTime = 2)
     public ResProductReservationPostDTOApiV1 postBy(ReqProductReservationPostDTOApiV1 reqDto, UUID productId, long userId) {
         // 예약 요청 검증
         var product = reservationValidator.validateReservationRequest(productId, userId, reqDto.getQuantity());

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     // 공통 모듈
-    implementation 'com.github.wonsongleejo:common-module:1.0.1'
+    implementation 'com.github.wonsongleejo:common-module:1.0.5'
 
     // SpringDoc OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'


### PR DESCRIPTION
### **📌 작업 내용**
- 공통모듈에 Redisson 기반 분산 락 적용을 위한 기능 추가 (tag 1.0.5)
  - `@DistributedLock` 커스텀 어노테이션 정의
  - DistributedLockAspect AOP 클래스 구현
  - RedissonConfig 설정 클래스 추가
- 상품 예약 API에 분산 락 적용
  - `@DistributedLock` 어노테이션을 postBy() 메서드에 적용하여 동시 다중 예약 요청 시 데이터 정합성 확보

---
- As-is
    - 다수의 유저가 동시에 동일 상품을 예약할 경우 한정된 재고를 초과하여 예약 성공할 가능성이 있었음
    - 실제로 테스트해본 결과, 5개 한정 수량의 상품을 40명의 유저가 동시에 요청을 보냈을 때 24건 예약 성공

- To-be
    - 5개 한정 수량의 상품을 40명의 유저가 동시에 요청을 보냈을 때 5건만 예약 성공

---

### **🧑‍💻 작업 유형**

- [x]  새로운 기능 추가


### **📷 관련 이미지**
- 락 적용 전 (5개 한정 상품에 대해 40건 동시 예약 요청 ->  24건 예약 성공)
  <img width="1207" alt="분산락적용전3" src="https://github.com/user-attachments/assets/0c51bf4e-9050-4282-96f0-d632740d91a8" />
  <img width="872" alt="분산락적용전5" src="https://github.com/user-attachments/assets/dcb512a6-796f-4354-a634-c514145f8386" />


<br><br>


- 락 적용 후 (5개 한정 상품에 대해 40건 동시 예약 요청 ->  5건 예약 성공)
  <img width="1201" alt="분산락적용후3" src="https://github.com/user-attachments/assets/15c5a0d7-ff88-4a3a-9c72-47edcb488375" />
  <img width="1206" alt="스크린샷 2025-04-29 오후 7 49 14" src="https://github.com/user-attachments/assets/7e3d8660-c716-4fb0-9fd0-849231079b7b" />


