### PR TITLE
refactor: 팝업스토어 예약 상태 변경 메서드에서 예약 취소 메서드 분리

### DIFF
--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV2.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV2.java
@@ -166,25 +166,40 @@ public class StoreReservationServiceImplApiV2 implements StoreReservationService
                 .build();
     }
 
+    // 예약 상태 변경 (예약 취소시 cancelReservation 호출)
     @Override
     public ResStoreReservationPutByIdStatusDTOApiV1 changeStatus(UserContext userContext, UUID storeReservationId, StoreReservationStatus status) {
         StoreReservationEntity entity = storeReservationRepository.findById(storeReservationId);
         if (entity == null) throw new CustomException(ResponseCode.NOT_FOUND);
 
-        // 예약 취소되면 예약 인원 수만큼 currentReservedPerson 감소
-        if (status == StoreReservationStatus.CANCELED && entity.getStatus() != StoreReservationStatus.CANCELED) {
-            int decreaseCount = entity.getPersonCount();
-            decreaseCurrentReservedPerson(entity.getTimeSlotId(), decreaseCount);
+        if (status == StoreReservationStatus.CANCELED) {
+            return cancelReservation(entity);
         }
 
         entity.changeStatus(status);
         StoreReservationEntity saved = storeReservationRepository.save(entity);
 
         PersonInfo personInfo = calculateCurrentAndMaxPerson(saved.getTimeSlotId());
-
         return ResStoreReservationPutByIdStatusDTOApiV1.from(saved, personInfo.getCurrentReservedPerson(), personInfo.getMaxPerson());
     }
 
+    // 예약 취소하는 비즈니스 로직 (캐시 수정 시 decreaseCurrentReservedPerson 호출)
+    private ResStoreReservationPutByIdStatusDTOApiV1 cancelReservation(StoreReservationEntity entity) {
+        if (entity.getStatus() == StoreReservationStatus.CANCELED) {
+            throw new CustomException(ResponseCode.DUPLICATED_REQUEST);
+        }
+
+        int decreaseCount = entity.getPersonCount();
+        decreaseCurrentReservedPerson(entity.getTimeSlotId(), decreaseCount);
+
+        entity.changeStatus(StoreReservationStatus.CANCELED);
+        StoreReservationEntity saved = storeReservationRepository.save(entity);
+
+        PersonInfo personInfo = calculateCurrentAndMaxPerson(saved.getTimeSlotId());
+        return ResStoreReservationPutByIdStatusDTOApiV1.from(saved, personInfo.getCurrentReservedPerson(), personInfo.getMaxPerson());
+    }
+
+    // 예약 취소로 인해 Redis 캐시만 수정하는 메서드
     private void decreaseCurrentReservedPerson(UUID timeSlotId, int decreaseCount) {
         String currentKey = "timeslot:" + timeSlotId + ":currentReservedPerson";
         Integer currentReservedPerson = getValueFromRedis(currentKey);

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV3.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV3.java
@@ -205,25 +205,40 @@ public class StoreReservationServiceImplApiV3 implements StoreReservationService
                 .build();
     }
 
+    // 예약 상태 변경 (예약 취소시 cancelReservation 호출)
     @Override
     public ResStoreReservationPutByIdStatusDTOApiV1 changeStatus(UserContext userContext, UUID storeReservationId, StoreReservationStatus status) {
         StoreReservationEntity entity = storeReservationRepository.findById(storeReservationId);
         if (entity == null) throw new CustomException(ResponseCode.NOT_FOUND);
 
-        // 예약 취소되면 예약 인원 수만큼 currentReservedPerson 감소
-        if (status == StoreReservationStatus.CANCELED && entity.getStatus() != StoreReservationStatus.CANCELED) {
-            int decreaseCount = entity.getPersonCount();
-            decreaseCurrentReservedPerson(entity.getTimeSlotId(), decreaseCount);
+        if (status == StoreReservationStatus.CANCELED) {
+            return cancelReservation(entity);
         }
 
         entity.changeStatus(status);
         StoreReservationEntity saved = storeReservationRepository.save(entity);
 
         PersonInfo personInfo = calculateCurrentAndMaxPerson(saved.getTimeSlotId());
-
         return ResStoreReservationPutByIdStatusDTOApiV1.from(saved, personInfo.getCurrentReservedPerson(), personInfo.getMaxPerson());
     }
 
+    // 예약 취소하는 비즈니스 로직 (캐시 수정 시 decreaseCurrentReservedPerson 호출)
+    private ResStoreReservationPutByIdStatusDTOApiV1 cancelReservation(StoreReservationEntity entity) {
+        if (entity.getStatus() == StoreReservationStatus.CANCELED) {
+            throw new CustomException(ResponseCode.DUPLICATED_REQUEST);
+        }
+
+        int decreaseCount = entity.getPersonCount();
+        decreaseCurrentReservedPerson(entity.getTimeSlotId(), decreaseCount);
+
+        entity.changeStatus(StoreReservationStatus.CANCELED);
+        StoreReservationEntity saved = storeReservationRepository.save(entity);
+
+        PersonInfo personInfo = calculateCurrentAndMaxPerson(saved.getTimeSlotId());
+        return ResStoreReservationPutByIdStatusDTOApiV1.from(saved, personInfo.getCurrentReservedPerson(), personInfo.getMaxPerson());
+    }
+
+    // 예약 취소로 인해 Redis 캐시만 수정하는 메서드
     private void decreaseCurrentReservedPerson(UUID timeSlotId, int decreaseCount) {
         String currentKey = "timeslot:" + timeSlotId + ":currentReservedPerson";
         Integer currentReservedPerson = getValueFromRedis(currentKey);

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV4.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/application/service/StoreReservationServiceImplApiV4.java
@@ -198,25 +198,40 @@ public class StoreReservationServiceImplApiV4 implements StoreReservationService
                 .build();
     }
 
+    // 예약 상태 변경 (예약 취소시 cancelReservation 호출)
     @Override
     public ResStoreReservationPutByIdStatusDTOApiV1 changeStatus(UserContext userContext, UUID storeReservationId, StoreReservationStatus status) {
         StoreReservationEntity entity = storeReservationRepository.findById(storeReservationId);
         if (entity == null) throw new CustomException(ResponseCode.NOT_FOUND);
 
-        // 예약 취소되면 예약 인원 수만큼 currentReservedPerson 감소
-        if (status == StoreReservationStatus.CANCELED && entity.getStatus() != StoreReservationStatus.CANCELED) {
-            int decreaseCount = entity.getPersonCount();
-            decreaseCurrentReservedPerson(entity.getTimeSlotId(), decreaseCount);
+        if (status == StoreReservationStatus.CANCELED) {
+            return cancelReservation(entity);
         }
 
         entity.changeStatus(status);
         StoreReservationEntity saved = storeReservationRepository.save(entity);
 
         PersonInfo personInfo = calculateCurrentAndMaxPerson(saved.getTimeSlotId());
-
         return ResStoreReservationPutByIdStatusDTOApiV1.from(saved, personInfo.getCurrentReservedPerson(), personInfo.getMaxPerson());
     }
 
+    // 예약 취소하는 비즈니스 로직 (캐시 수정 시 decreaseCurrentReservedPerson 호출)
+    private ResStoreReservationPutByIdStatusDTOApiV1 cancelReservation(StoreReservationEntity entity) {
+        if (entity.getStatus() == StoreReservationStatus.CANCELED) {
+            throw new CustomException(ResponseCode.DUPLICATED_REQUEST);
+        }
+
+        int decreaseCount = entity.getPersonCount();
+        decreaseCurrentReservedPerson(entity.getTimeSlotId(), decreaseCount);
+
+        entity.changeStatus(StoreReservationStatus.CANCELED);
+        StoreReservationEntity saved = storeReservationRepository.save(entity);
+
+        PersonInfo personInfo = calculateCurrentAndMaxPerson(saved.getTimeSlotId());
+        return ResStoreReservationPutByIdStatusDTOApiV1.from(saved, personInfo.getCurrentReservedPerson(), personInfo.getMaxPerson());
+    }
+
+    // 예약 취소로 인해 Redis 캐시만 수정하는 메서드
     private void decreaseCurrentReservedPerson(UUID timeSlotId, int decreaseCount) {
         String currentKey = "timeslot:" + timeSlotId + ":currentReservedPerson";
         Integer currentReservedPerson = getValueFromRedis(currentKey);

--- a/store-reservation-service/src/main/resources/application.yml
+++ b/store-reservation-service/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
### **📌 작업 내용**

- As-is
    - 예약 변경 메서드에서 예약 취소일 경우에 Redis 캐싱하는 로직 구현했었습니다.
- To-be
    - 추후 Kafka 적용을 하게 될 것을 생각했을 때 유일하게 예약 취소할 때만 부가적인 로직이 계속 추가되므로 예약 취소 메서드를 따로 분리하였습니다.
    - 따로 API 를 나눠야하나 생각했지만 예약 상태 변경과 예약 취소는 동일한 상태 변경이므로 메서드만 분리하기로 결정하였습니다.

### **🧑‍💻 작업 유형**

- [ ]  새로운 기능 추가
- [ ]  버그 수정
- [X]  코드 리팩토링
- [ ]  문서 수정
- [ ]  설정 변경
- [ ]  CI/CD 변경
- [ ]  테스트 추가
- [ ]  테스트 수정