### PR TITLE
refactor: 슬랙 domain 폴더 안에 slack 폴더 제거

### DIFF
--- a/slack-service/src/main/java/com/monkey/slackservice/application/service/SlackServiceImpl.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/application/service/SlackServiceImpl.java
@@ -2,8 +2,8 @@ package com.monkey.slackservice.application.service;
 
 import com.monkey.slackservice.application.dto.request.ReqSlackStoreMessageDTOApiV1;
 import com.monkey.slackservice.application.dto.response.ResSlackMessageDTOApiV1;
-import com.monkey.slackservice.domain.slack.entity.SlackEntity;
-import com.monkey.slackservice.domain.slack.repository.SlackRepository;
+import com.monkey.slackservice.domain.entity.SlackEntity;
+import com.monkey.slackservice.domain.repository.SlackRepository;
 import com.monkey.slackservice.infrastructure.client.StoreReservationClient;
 import com.monkey.slackservice.infrastructure.dto.response.ResStoreReservationGetByIdDTOApiV1;
 import com.monkey.slackservice.infrastructure.message.SlackMessageFormatter;

--- a/slack-service/src/main/java/com/monkey/slackservice/domain/entity/SlackEntity.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/domain/entity/SlackEntity.java
@@ -1,4 +1,4 @@
-package com.monkey.slackservice.domain.slack.entity;
+package com.monkey.slackservice.domain.entity;
 
 import com.monkey.common_module.entity.BaseEntity;
 import jakarta.persistence.*;

--- a/slack-service/src/main/java/com/monkey/slackservice/domain/repository/SlackRepository.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/domain/repository/SlackRepository.java
@@ -1,0 +1,8 @@
+package com.monkey.slackservice.domain.repository;
+
+import com.monkey.slackservice.domain.entity.SlackEntity;
+
+public interface SlackRepository {
+    SlackEntity save(SlackEntity slackEntity);
+    long count();
+}

--- a/slack-service/src/main/java/com/monkey/slackservice/domain/slack/repository/SlackRepository.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/domain/slack/repository/SlackRepository.java
@@ -1,8 +1,0 @@
-package com.monkey.slackservice.domain.slack.repository;
-
-import com.monkey.slackservice.domain.slack.entity.SlackEntity;
-
-public interface SlackRepository {
-    SlackEntity save(SlackEntity slackEntity);
-    long count();
-}

--- a/slack-service/src/main/java/com/monkey/slackservice/domain/vo/SlackMessageType.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/domain/vo/SlackMessageType.java
@@ -1,4 +1,4 @@
-package com.monkey.slackservice.domain.slack.vo;
+package com.monkey.slackservice.domain.vo;
 
 public enum SlackMessageType {
     STORE_SCHEDULED,

--- a/slack-service/src/main/java/com/monkey/slackservice/infrastructure/persistence/slack/SlackJpaRepository.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/infrastructure/persistence/slack/SlackJpaRepository.java
@@ -1,6 +1,6 @@
 package com.monkey.slackservice.infrastructure.persistence.slack;
 
-import com.monkey.slackservice.domain.slack.entity.SlackEntity;
+import com.monkey.slackservice.domain.entity.SlackEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;

--- a/slack-service/src/main/java/com/monkey/slackservice/infrastructure/persistence/slack/SlackRepositoryImpl.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/infrastructure/persistence/slack/SlackRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.monkey.slackservice.infrastructure.persistence.slack;
 
-import com.monkey.slackservice.domain.slack.entity.SlackEntity;
-import com.monkey.slackservice.domain.slack.repository.SlackRepository;
+import com.monkey.slackservice.domain.entity.SlackEntity;
+import com.monkey.slackservice.domain.repository.SlackRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 


### PR DESCRIPTION
### **📌 작업 내용**

이 PR에서 추가된 기능 또는 수정 사항에 대해 간략히 설명해주세요.

- As-is
![image](https://github.com/user-attachments/assets/0099c7cf-e051-44fe-b750-7561c384edab)
    - 슬랙 도메인에 domain 폴더 속에 slack 폴더가 존재하고 그 안에 entity, repository 등 폴더 들이 존재했습니다.
- To-be
    - 컨벤션을 맞추기 위해 제거하였습니다.

### **🧑‍💻 작업 유형**

- [ ]  새로운 기능 추가
- [ ]  버그 수정
- [X]  코드 리팩토링
- [ ]  문서 수정
- [ ]  설정 변경
- [ ]  CI/CD 변경
- [ ]  테스트 추가
- [ ]  테스트 수정
