### PR TITLE
Feat: 상품 예약 취소에 kafka 적용

### DIFF
--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -48,7 +48,7 @@ spring:
             - AuthorizationHeaderFilter
           uri: lb://product-reservation-service
           predicates:
-            - Path=/v1/product-reservations/**, /v2/product-reservations/**, /springdoc/openapi3-product-reservation-service.json
+            - Path=/v1/product-reservations/**, /v2/product-reservations/**,, /v3/product-reservations/**, /springdoc/openapi3-product-reservation-service.json
 
         # Slack
         - id: slack-service

--- a/product-reservation-service/build.gradle
+++ b/product-reservation-service/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     // 공통 모듈
-    implementation 'com.github.wonsongleejo:common-module:1.0.5'
+    implementation 'com.github.wonsongleejo:common-module:1.0.6'
 
     // SpringDoc OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
@@ -27,6 +27,8 @@ dependencies {
 
     implementation 'org.postgresql:postgresql:42.7.1'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 dependencyManagement {

--- a/product-reservation-service/build.gradle
+++ b/product-reservation-service/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     // 공통 모듈
-    implementation 'com.github.wonsongleejo:common-module:1.0.6'
+    implementation 'com.github.wonsongleejo:common-module:1.0.7'
 
     // SpringDoc OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/event/ProductReservationEventProduceV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/event/ProductReservationEventProduceV1.java
@@ -1,0 +1,7 @@
+package com.monkey.productreservationservice.application.event;
+
+import com.monkey.productreservationservice.application.event.dto.ProductStockIncreasePayloadV1;
+
+public interface ProductReservationEventProduceV1 {
+    void increaseStock(ProductStockIncreasePayloadV1 build);
+}

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/event/dto/ProductStockIncreasePayloadV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/event/dto/ProductStockIncreasePayloadV1.java
@@ -1,0 +1,13 @@
+package com.monkey.productreservationservice.application.event.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class ProductStockIncreasePayloadV1 {
+    private UUID productId;
+    private Integer quantity;
+}

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/service/v3/ProductReservationServiceApiV3.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/application/service/v3/ProductReservationServiceApiV3.java
@@ -1,0 +1,161 @@
+package com.monkey.productreservationservice.application.service.v3;
+
+import com.monkey.common_module.aop.AccessLevel;
+import com.monkey.common_module.aop.CheckUserRole;
+import com.monkey.common_module.dto.ResponseCode;
+import com.monkey.common_module.exception.CustomException;
+import com.monkey.productreservationservice.application.dto.request.ReqProductReservationPostDTOApiV1;
+import com.monkey.productreservationservice.application.dto.response.ResProductReservationGetByIdDTOApiV1;
+import com.monkey.productreservationservice.application.dto.response.ResProductReservationGetDTOApiV1;
+import com.monkey.productreservationservice.application.dto.response.ResProductReservationPostByIdCancelDTOApiV1;
+import com.monkey.productreservationservice.application.dto.response.ResProductReservationPostDTOApiV1;
+import com.monkey.productreservationservice.application.event.ProductReservationEventProduceV1;
+import com.monkey.productreservationservice.application.event.dto.ProductStockIncreasePayloadV1;
+import com.monkey.productreservationservice.application.validator.v1.ProductReservationReadValidator;
+import com.monkey.productreservationservice.application.validator.v2.ProductReservationValidatorV2;
+import com.monkey.productreservationservice.domain.entity.ProductReservationEntity;
+import com.monkey.productreservationservice.domain.repository.ProductReservationRepository;
+import com.monkey.productreservationservice.domain.vo.ProductReservationStatus;
+import com.monkey.productreservationservice.infrastructure.feignclient.ProductFeignClientApiV1;
+import com.monkey.productreservationservice.infrastructure.feignclient.dto.response.ResProductClientGetByIdDTOApiV1;
+import com.monkey.productreservationservice.infrastructure.feignclient.dto.response.ResStoreClientGetByIdDTOApiV1;
+import com.monkey.productreservationservice.infrastructure.feignclient.dto.response.ResUserClientGetByIdDTOApiV1;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProductReservationServiceApiV3 {
+    private final ProductReservationRepository productReservationRepository;
+    private final ProductReservationValidatorV2 reservationValidator;
+    private final ProductReservationReadValidator readValidator;
+    private final ProductFeignClientApiV1 productFeignClientApiV1;
+    private final ProductReservationEventProduceV1 productReservationEventProduce;
+
+    // 예약 등록
+    @Transactional
+    @CheckUserRole(AccessLevel.USER)
+    public ResProductReservationPostDTOApiV1 postBy(ReqProductReservationPostDTOApiV1 reqDto, UUID productId, Long userId) {
+        // 예약 요청 검증
+        var product = reservationValidator.validateReservationRequest(productId, userId, reqDto.getQuantity());
+        ProductReservationEntity productReservation = saveNewReservation(product, reqDto, userId);
+
+        try {
+            requestStockDecrease(productId, userId, reqDto.getQuantity());
+        } catch (Exception e) {
+            requestReservationFail(productReservation, userId, reqDto.getQuantity());
+            throw new CustomException(ResponseCode.PRODUCT_OUT_OF_STOCK);
+        }
+        return ResProductReservationPostDTOApiV1.of(productReservation);
+    }
+
+    // 예약 취소
+    @CheckUserRole(AccessLevel.USER)
+    public ResProductReservationPostByIdCancelDTOApiV1 cancelBy(UUID productReservationId, long userId) {
+        ProductReservationEntity productReservation = getActiveProductReservationById(productReservationId);
+        UUID productId = productReservation.getProductId();
+        int quantity = productReservation.getQuantity();
+
+        productReservation.cancel(userId);
+
+        // 상품 재고 복원
+        productReservationEventProduce.increaseStock(
+                ProductStockIncreasePayloadV1.builder()
+                        .productId(productId)
+                        .quantity(quantity)
+                        .build()
+        );
+
+        return ResProductReservationPostByIdCancelDTOApiV1.of(productReservationRepository.save(productReservation));
+    }
+
+    // 예약 취소 실패
+    @Transactional
+    public void cancelFailed(UUID productId, Long userId) {
+        ProductReservationEntity productReservation = productReservationRepository.findByProductIdAndUserId(productId, userId)
+                .orElseThrow(()-> new CustomException(ResponseCode.NOT_FOUND));
+
+        // 상태 값, soft delete 되돌리기
+        productReservation.cancelFailed();
+    }
+
+    // 예약내역 전체 조회
+    @CheckUserRole(AccessLevel.ALL)
+    public ResProductReservationGetDTOApiV1 getBy(Pageable pageable) {
+        Page<ProductReservationEntity> productReservationPage = productReservationRepository.findAllByIsDeletedFalse(pageable);
+        return ResProductReservationGetDTOApiV1.of(productReservationPage);
+    }
+
+    // 예약내역 단건 조회
+    @CheckUserRole(AccessLevel.ALL)
+    public ResProductReservationGetByIdDTOApiV1 getById(UUID productReservationId) {
+        ProductReservationEntity productReservation = getActiveProductReservationById(productReservationId);
+
+        ResProductClientGetByIdDTOApiV1.Product resProduct = readValidator.validateProduct(productReservation.getProductId());
+        ResStoreClientGetByIdDTOApiV1.Store resStore = readValidator.validateStore(productReservation.getStoreId());
+        ResUserClientGetByIdDTOApiV1.User resUser = readValidator.validateUser(productReservation.getUserId());
+
+        return ResProductReservationGetByIdDTOApiV1.of(productReservation, resProduct, resStore, resUser);
+    }
+
+    // 개인 예약내역 조회
+    @Cacheable(value = "product-reservation", key = "#userId")
+    @CheckUserRole(AccessLevel.USER)
+    public ResProductReservationGetDTOApiV1 getByUserId(long userId, Pageable pageable) {
+        Page<ProductReservationEntity> productReservationPage =
+                productReservationRepository.findByUserIdAndIsDeletedFalse(userId, pageable);
+        return ResProductReservationGetDTOApiV1.of(productReservationPage);
+    }
+
+
+    /// ========================================== 서비스 내부 검증 로직 ==========================================
+
+    // 존재하는 예약 검증 메서드
+    private ProductReservationEntity getActiveProductReservationById(UUID productReservationId) {
+        return productReservationRepository.findByProductReservationIdAndIsDeletedFalse(productReservationId)
+                .orElseThrow(() -> new CustomException(ResponseCode.NOT_FOUND));
+    }
+
+    // 상품 예약 엔티티 생성, 저장
+    private ProductReservationEntity saveNewReservation(ResProductClientGetByIdDTOApiV1.Product product, ReqProductReservationPostDTOApiV1 reqDto, long userId) {
+        ProductReservationEntity productReservationEntity = ProductReservationEntity.builder()
+                .productId(product.getProductId())
+                .userId(userId)
+                .storeId(product.getStore().getStoreId())
+                .quantity(reqDto.getQuantity())
+                .status(ProductReservationStatus.PENDING_PICKUP)
+                .build();
+
+        productReservationEntity = productReservationRepository.save(productReservationEntity);
+        log.info("[상품 예약 생성] userId={}, productId={}, quantity={}", userId, product.getProductId(), reqDto.getQuantity());
+        return productReservationEntity;
+    }
+
+    // 상품 재고 감소 요청
+    private void requestStockDecrease(UUID productId, long userId, int quantity) {
+        try {
+            // DB 재고 차감
+            productFeignClientApiV1.decreaseStock(productId, userId, quantity);
+            log.info("[상품 재고 차감 요청] productId={}, userId={}, quantity={}", productId, userId, quantity);
+
+        } catch (Exception e) {
+            log.error("[DB 재고 차감 실패] productId={}, userId={}, quantity={}", productId, userId, quantity);
+            throw new CustomException(ResponseCode.PRODUCT_FEIGN_CLIENT_ERROR);
+        }
+    }
+
+    // 상품 예약 실패
+    private void requestReservationFail(ProductReservationEntity productReservation, long userId, int quantity) {
+        productReservation.fail(userId);
+        productReservationRepository.save(productReservation);
+        log.error("[재고 부족으로 인해 예약 실패] reservationId={}", productReservation.getProductReservationId());
+    }
+}

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/domain/entity/ProductReservationEntity.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/domain/entity/ProductReservationEntity.java
@@ -56,6 +56,11 @@ public class ProductReservationEntity extends BaseEntity {
         this.delete(userId);
     }
 
+    public void cancelFailed() {
+        this.status = ProductReservationStatus.PENDING_PICKUP;
+        this.deleteFailure();
+    }
+
     public void fail(long userId) {
         if (this.getIsDeleted() || this.status == ProductReservationStatus.CANCELED || this.status == ProductReservationStatus.PICKED_UP || this.status == ProductReservationStatus.FAILED) {
             throw new CustomException(ResponseCode.DUPLICATED_REQUEST);

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/domain/repository/ProductReservationRepository.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/domain/repository/ProductReservationRepository.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 public interface ProductReservationRepository {
     ProductReservationEntity save(ProductReservationEntity entity);
     Optional<ProductReservationEntity> findByProductReservationIdAndIsDeletedFalse(UUID productReservationId);
+    Optional<ProductReservationEntity> findByProductIdAndUserId(UUID productId, Long userId);
     Page<ProductReservationEntity> findAllByIsDeletedFalse(Pageable pageable);
     Page<ProductReservationEntity> findByUserIdAndIsDeletedFalse(long userId, Pageable pageable);
     boolean existsByUserIdAndProductIdAndIsDeletedFalse(long userId, UUID productId);

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/config/KafkaConfig.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/config/KafkaConfig.java
@@ -1,0 +1,17 @@
+package com.monkey.productreservationservice.infrastructure.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+
+    @Bean
+    public NewTopic reservationCancelSuccessTopic() {
+        // 토픽명 : <프로듀서명>.<컨슈머명>.<이벤트-상태>
+        return new NewTopic("product-reservation.product.reservation-cancel-success", 1, (short) 1);
+    }
+}

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/config/KafkaConsumerConfig.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,35 @@
+package com.monkey.productreservationservice.infrastructure.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    Map<String, Object> props = new HashMap<>();
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String BOOTSTRAP_SERVERS;
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "reservation-cancel-group");
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 1000);
+
+        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), new StringDeserializer());
+    }
+}

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/config/KafkaProducerConfig.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/config/KafkaProducerConfig.java
@@ -1,5 +1,6 @@
 package com.monkey.productreservationservice.infrastructure.config;
 
+import com.monkey.common_module.kafka.UserHeaderProducerInterceptor;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -35,6 +36,7 @@ public class KafkaProducerConfig {
         props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true); // 메시지 중복 방지
         props.put(ProducerConfig.ACKS_CONFIG, "all"); // 전송 성공 여부
         props.put(ProducerConfig.RETRIES_CONFIG, 3); // 재시도 횟수
+        props.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, UserHeaderProducerInterceptor.class.getName());
 
         return new DefaultKafkaProducerFactory<>(props, new StringSerializer(), new StringSerializer());
     }

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/config/KafkaProducerConfig.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/config/KafkaProducerConfig.java
@@ -1,0 +1,41 @@
+package com.monkey.productreservationservice.infrastructure.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaProducerConfig {
+
+    Map<String, Object> props = new HashMap<>();
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String BOOTSTRAP_SERVERS;
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true); // 메시지 중복 방지
+        props.put(ProducerConfig.ACKS_CONFIG, "all"); // 전송 성공 여부
+        props.put(ProducerConfig.RETRIES_CONFIG, 3); // 재시도 횟수
+
+        return new DefaultKafkaProducerFactory<>(props, new StringSerializer(), new StringSerializer());
+    }
+}

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/kafka/KafkaEventListenerV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/kafka/KafkaEventListenerV1.java
@@ -1,0 +1,33 @@
+package com.monkey.productreservationservice.infrastructure.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.monkey.productreservationservice.application.service.v3.ProductReservationServiceApiV3;
+import com.monkey.productreservationservice.infrastructure.kafka.dto.ProductStockIncreaseFailPayloadV1;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KafkaEventListenerV1 {
+    private final ProductReservationServiceApiV3 productReservationService;
+
+    @KafkaListener(groupId = "reservation-cancel-failed", topics = "product.product-reservation.reservation-cancel-failed")
+    public void increaseStockFailed(
+            @Payload String payload,
+            @Header(value = "X-User-Id", required = false) String userId
+    ) {
+        try {
+            log.info("receive cancel failed event sent from product");
+            ObjectMapper objectMapper = new ObjectMapper();
+            ProductStockIncreaseFailPayloadV1 productStockIncreaseFailPayload = objectMapper.readValue(payload, ProductStockIncreaseFailPayloadV1.class);
+            productReservationService.cancelFailed(productStockIncreaseFailPayload.getProductId(), Long.valueOf(userId));
+        }catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/kafka/KafkaEventPublisherV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/kafka/KafkaEventPublisherV1.java
@@ -1,0 +1,27 @@
+package com.monkey.productreservationservice.infrastructure.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.monkey.productreservationservice.application.event.ProductReservationEventProduceV1;
+import com.monkey.productreservationservice.application.event.dto.ProductStockIncreasePayloadV1;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaEventPublisherV1 implements ProductReservationEventProduceV1 {
+    private final static String INCREASE_STOCK_TOPIC = "product-reservation.product.reservation-cancel-success";
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void increaseStock(ProductStockIncreasePayloadV1 build) {
+        try {
+            String payload = objectMapper.writeValueAsString(build);
+            kafkaTemplate.send(INCREASE_STOCK_TOPIC, payload);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/kafka/dto/ProductStockIncreaseFailPayloadV1.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/kafka/dto/ProductStockIncreaseFailPayloadV1.java
@@ -1,0 +1,16 @@
+package com.monkey.productreservationservice.infrastructure.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductStockIncreaseFailPayloadV1 {
+    private UUID productId;
+}

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/persistence/ProductReservationJpaRepository.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/persistence/ProductReservationJpaRepository.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 
 public interface ProductReservationJpaRepository extends JpaRepository<ProductReservationEntity, UUID> {
     Optional<ProductReservationEntity> findByProductReservationIdAndIsDeletedFalse(UUID productReservationId);
+    Optional<ProductReservationEntity> findByProductIdAndUserId(UUID productId, Long userId);
     Page<ProductReservationEntity> findAllByIsDeletedFalse(Pageable pageable);
     Page<ProductReservationEntity> findByUserIdAndIsDeletedFalse(long userId, Pageable pageable);
     boolean existsByUserIdAndProductIdAndIsDeletedFalse(long userId, UUID productId);

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/persistence/ProductReservationRepositoryImpl.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/infrastructure/persistence/ProductReservationRepositoryImpl.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -24,6 +23,11 @@ public class ProductReservationRepositoryImpl implements ProductReservationRepos
     @Override
     public Optional<ProductReservationEntity> findByProductReservationIdAndIsDeletedFalse(UUID productReservationId) {
         return productReservationJpaRepository.findByProductReservationIdAndIsDeletedFalse(productReservationId);
+    }
+
+    @Override
+    public Optional<ProductReservationEntity> findByProductIdAndUserId(UUID productId, Long userId) {
+        return productReservationJpaRepository.findByProductIdAndUserId(productId, userId);
     }
 
     @Override

--- a/product-reservation-service/src/main/java/com/monkey/productreservationservice/presentation/controller/v3/ProductReservationControllerApiV3.java
+++ b/product-reservation-service/src/main/java/com/monkey/productreservationservice/presentation/controller/v3/ProductReservationControllerApiV3.java
@@ -1,0 +1,69 @@
+package com.monkey.productreservationservice.presentation.controller.v3;
+
+import com.monkey.common_module.dto.ResDTO;
+import com.monkey.productreservationservice.application.dto.request.ReqProductReservationPostDTOApiV1;
+import com.monkey.productreservationservice.application.dto.response.ResProductReservationGetByIdDTOApiV1;
+import com.monkey.productreservationservice.application.dto.response.ResProductReservationGetDTOApiV1;
+import com.monkey.productreservationservice.application.dto.response.ResProductReservationPostByIdCancelDTOApiV1;
+import com.monkey.productreservationservice.application.dto.response.ResProductReservationPostDTOApiV1;
+import com.monkey.productreservationservice.application.service.v3.ProductReservationServiceApiV3;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/v3/product-reservations")
+public class ProductReservationControllerApiV3 {
+    private final ProductReservationServiceApiV3 productReservationService;
+
+    // 예약 등록
+    @PostMapping("/{productId}")
+    public ResponseEntity<ResDTO<ResProductReservationPostDTOApiV1>> postBy(
+            @RequestBody @Valid ReqProductReservationPostDTOApiV1 reqDto,
+            @PathVariable UUID productId,
+            @RequestHeader("X-User-Id") Long userId
+    ) {
+        ResProductReservationPostDTOApiV1 resDto = productReservationService.postBy(reqDto, productId, userId);
+        return new ResponseEntity<>(ResDTO.success(resDto), HttpStatus.OK);
+    }
+
+    // 예약 취소
+    @PostMapping("/{productReservationId}/cancel")
+    public ResponseEntity<ResDTO<ResProductReservationPostByIdCancelDTOApiV1>> cancelBy(
+            @PathVariable UUID productReservationId,
+            @RequestHeader("X-User-Id") long userId
+    ) {
+        ResProductReservationPostByIdCancelDTOApiV1 resDto = productReservationService.cancelBy(productReservationId, userId);
+        return new ResponseEntity<>(ResDTO.success(resDto), HttpStatus.OK);
+    }
+
+    // 예약내역 전체 조회
+    @GetMapping
+    public ResponseEntity<ResDTO<ResProductReservationGetDTOApiV1>> getBy(Pageable pageable) {
+        ResProductReservationGetDTOApiV1 resDto = productReservationService.getBy(pageable);
+        return new ResponseEntity<>(ResDTO.success(resDto), HttpStatus.OK);
+    }
+
+    // 개인 예약내역 조회
+    @GetMapping("/my")
+    public ResponseEntity<ResDTO<ResProductReservationGetDTOApiV1>> getMyProductReservations(
+            @RequestHeader("X-User-Id") long userId,
+            Pageable pageable
+    ) {
+        ResProductReservationGetDTOApiV1 resDto = productReservationService.getByUserId(userId, pageable);
+        return new ResponseEntity<>(ResDTO.success(resDto), HttpStatus.OK);
+    }
+
+    // 예약내역 단건 조회
+    @GetMapping("/{productReservationId}")
+    public ResponseEntity<ResDTO<ResProductReservationGetByIdDTOApiV1>> getById(@PathVariable UUID productReservationId) {
+        ResProductReservationGetByIdDTOApiV1 resDto = productReservationService.getById(productReservationId);
+        return new ResponseEntity<>(ResDTO.success(resDto), HttpStatus.OK);
+    }
+}

--- a/product-reservation-service/src/main/resources/application.yml
+++ b/product-reservation-service/src/main/resources/application.yml
@@ -26,6 +26,9 @@ spring:
     access-token-expiration: ${ACCESS_TOKEN_EXPIRATION}
     refresh-token-expiration: ${REFRESH_TOKEN_EXPIRATION}
 
+  kafka:
+    bootstrap-servers: ${KAFKA_HOST}:${KAFKA_PORT}
+
 server:
   port: 8085
 

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 
     implementation 'org.postgresql:postgresql:42.7.1'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 dependencyManagement {

--- a/product-service/build.gradle
+++ b/product-service/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     // 공통 모듈
-    implementation 'com.github.wonsongleejo:common-module:1.0.5'
+    implementation 'com.github.wonsongleejo:common-module:1.0.7'
 
     // SpringDoc OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'

--- a/product-service/src/main/java/com/monkey/productservice/application/event/ProductEventProduceV1.java
+++ b/product-service/src/main/java/com/monkey/productservice/application/event/ProductEventProduceV1.java
@@ -1,0 +1,7 @@
+package com.monkey.productservice.application.event;
+
+import com.monkey.productservice.application.event.dto.ProductStockIncreaseFailPayloadV1;
+
+public interface ProductEventProduceV1 {
+    void increaseStockFailed(ProductStockIncreaseFailPayloadV1 build);
+}

--- a/product-service/src/main/java/com/monkey/productservice/application/event/dto/ProductStockIncreaseFailPayloadV1.java
+++ b/product-service/src/main/java/com/monkey/productservice/application/event/dto/ProductStockIncreaseFailPayloadV1.java
@@ -1,0 +1,12 @@
+package com.monkey.productservice.application.event.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class ProductStockIncreaseFailPayloadV1 {
+    private UUID productId;
+}

--- a/product-service/src/main/java/com/monkey/productservice/application/service/v3/ProductServiceApiV3.java
+++ b/product-service/src/main/java/com/monkey/productservice/application/service/v3/ProductServiceApiV3.java
@@ -1,0 +1,7 @@
+package com.monkey.productservice.application.service.v3;
+
+import java.util.UUID;
+
+public interface ProductServiceApiV3 {
+    void increaseStock(UUID productId, int quantity);
+}

--- a/product-service/src/main/java/com/monkey/productservice/application/service/v3/ProductServiceImplApiV3.java
+++ b/product-service/src/main/java/com/monkey/productservice/application/service/v3/ProductServiceImplApiV3.java
@@ -1,0 +1,47 @@
+package com.monkey.productservice.application.service.v3;
+
+import com.monkey.common_module.dto.ResponseCode;
+import com.monkey.common_module.exception.CustomException;
+import com.monkey.productservice.application.event.ProductEventProduceV1;
+import com.monkey.productservice.application.event.dto.ProductStockIncreaseFailPayloadV1;
+import com.monkey.productservice.domain.entity.ProductEntity;
+import com.monkey.productservice.domain.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProductServiceImplApiV3 implements ProductServiceApiV3 {
+    private final ProductRepository productRepository;
+    private final ProductEventProduceV1 productEventProduce;
+
+    // 존재하는 상품 검증 메서드
+    private ProductEntity getActiveProductById(UUID productId) {
+        return productRepository.findByProductIdAndIsDeletedFalse(productId)
+                .orElseThrow(() -> new CustomException(ResponseCode.NOT_FOUND));
+    }
+
+    // 상품 재고 증가
+    @Transactional
+    @Override
+    public void increaseStock(UUID productId, int quantity) {
+        try{
+            ProductEntity productEntity = getActiveProductById(productId);
+            if(quantity == 1) throw new Exception("실패");
+            productEntity.increaseStock(quantity);
+            productRepository.save(productEntity);
+        } catch (Exception e){
+            log.error(e.getMessage());
+            productEventProduce.increaseStockFailed(
+                    ProductStockIncreaseFailPayloadV1.builder()
+                            .productId(productId)
+                            .build()
+            );
+        }
+    }
+}

--- a/product-service/src/main/java/com/monkey/productservice/infrastructure/config/KafkaConfig.java
+++ b/product-service/src/main/java/com/monkey/productservice/infrastructure/config/KafkaConfig.java
@@ -1,0 +1,16 @@
+package com.monkey.productservice.infrastructure.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+    @Bean
+    public NewTopic reservationCancelFailedTopic() {
+        // 토픽명 : <프로듀서명>.<컨슈머명>.<이벤트-상태>
+        return new NewTopic("product.product-reservation.reservation-cancel-failed", 1, (short) 1);
+    }
+}

--- a/product-service/src/main/java/com/monkey/productservice/infrastructure/config/KafkaConsumerConfig.java
+++ b/product-service/src/main/java/com/monkey/productservice/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,35 @@
+package com.monkey.productservice.infrastructure.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    Map<String, Object> props = new HashMap<>();
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String BOOTSTRAP_SERVERS;
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "reservation-cancel-group");
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 1000);
+
+        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), new StringDeserializer());
+    }
+}

--- a/product-service/src/main/java/com/monkey/productservice/infrastructure/config/KafkaProducerConfig.java
+++ b/product-service/src/main/java/com/monkey/productservice/infrastructure/config/KafkaProducerConfig.java
@@ -1,0 +1,41 @@
+package com.monkey.productservice.infrastructure.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaProducerConfig {
+
+    Map<String, Object> props = new HashMap<>();
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String BOOTSTRAP_SERVERS;
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true); // 메시지 중복 방지
+        props.put(ProducerConfig.ACKS_CONFIG, "all"); // 전송 성공 여부
+        props.put(ProducerConfig.RETRIES_CONFIG, 3); // 재시도 횟수
+
+        return new DefaultKafkaProducerFactory<>(props, new StringSerializer(), new StringSerializer());
+    }
+}

--- a/product-service/src/main/java/com/monkey/productservice/infrastructure/kafka/KafkaEventListenerV1.java
+++ b/product-service/src/main/java/com/monkey/productservice/infrastructure/kafka/KafkaEventListenerV1.java
@@ -1,0 +1,29 @@
+package com.monkey.productservice.infrastructure.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.monkey.productservice.application.service.v3.ProductServiceApiV3;
+import com.monkey.productservice.infrastructure.kafka.dto.ProductStockIncreasePayloadV1;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KafkaEventListenerV1 {
+    private final ProductServiceApiV3 productService;
+
+    @KafkaListener(groupId = "reservation-cancel", topics = "product-reservation.product.reservation-cancel-success")
+    public void increaseStock(@Payload String payload) {
+        try {
+            log.info("receive reservation event sent from product-reservation");
+            ObjectMapper objectMapper = new ObjectMapper();
+            ProductStockIncreasePayloadV1 productStockIncreasePayload = objectMapper.readValue(payload, ProductStockIncreasePayloadV1.class);
+            productService.increaseStock(productStockIncreasePayload.getProductId(), productStockIncreasePayload.getQuantity());
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+    }
+}

--- a/product-service/src/main/java/com/monkey/productservice/infrastructure/kafka/KafkaEventPublisherV1.java
+++ b/product-service/src/main/java/com/monkey/productservice/infrastructure/kafka/KafkaEventPublisherV1.java
@@ -1,0 +1,29 @@
+package com.monkey.productservice.infrastructure.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.monkey.productservice.application.event.ProductEventProduceV1;
+import com.monkey.productservice.application.event.dto.ProductStockIncreaseFailPayloadV1;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaEventPublisherV1 implements ProductEventProduceV1 {
+    private final static String INCREASE_STOCK_FAILED_TOPIC = "product.product-reservation.reservation-cancel-failed";
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void increaseStockFailed(ProductStockIncreaseFailPayloadV1 build) {
+        try {
+            String payload = objectMapper.writeValueAsString(build);
+            kafkaTemplate.send(INCREASE_STOCK_FAILED_TOPIC, payload);
+        }catch (JsonProcessingException e){
+            e.printStackTrace();
+        }
+    }
+}

--- a/product-service/src/main/java/com/monkey/productservice/infrastructure/kafka/dto/ProductStockIncreasePayloadV1.java
+++ b/product-service/src/main/java/com/monkey/productservice/infrastructure/kafka/dto/ProductStockIncreasePayloadV1.java
@@ -1,0 +1,11 @@
+package com.monkey.productservice.infrastructure.kafka.dto;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class ProductStockIncreasePayloadV1 {
+    private UUID productId;
+    private int quantity;
+}

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -31,6 +31,9 @@ spring:
       host: localhost
       port: 6379
 
+  kafka:
+    bootstrap-servers: ${KAFKA_HOST}:${KAFKA_PORT}
+
 
 server:
   port: 8084


### PR DESCRIPTION
### **📌 작업 내용**

상품 예약 취소 기능에 kafka 적용

- As-is
    - 상품 예약 취소 시 FeignClient 처리
- To-be
    - Kafka로 변경
    - 상품 재고에 적용했던 Redis 캐싱 처리 삭제

### **🧑‍💻 작업 유형**

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [x]  코드 리팩토링
- [ ]  문서 수정
- [ ]  설정 변경
- [ ]  CI/CD 변경
- [ ]  테스트 추가
- [ ]  테스트 수정

### **📷 관련 이미지**

해당 Pull Request와 관련된 이미지가 있을 경우 여기에 첨부해주세요.

### **🚨 주의 사항**

- 상품 예약 취소 실패에 대한 kafka적용 시 Header값을 사용하기 위해 interceptor 추가 (common-module)
- 추후에 outbox 패턴을 적용하여 데이터 일관성 문제를 보완하고자 함

### **🤔 토론**

기능을 추가하면서 생긴 고민을 작성해주세요.
