### PR TITLE
refactor: Entity에서 @Builder 제거함에 따라 정적 팩토리 메서드로 수정

### DIFF
--- a/slack-service/src/main/java/com/monkey/slackservice/application/service/SlackServiceImpl.java
+++ b/slack-service/src/main/java/com/monkey/slackservice/application/service/SlackServiceImpl.java
@@ -29,11 +29,13 @@ public class SlackServiceImpl implements SlackService {
 
         String message = slackMessageFormatter.format(reservation.getStatus());
 
-        SlackEntity savedEntity = slackRepository.save(SlackEntity.builder()
-                .reservationId(slackRequest.getStoreReservationId())
-                .slackId(slackRequest.getSlackId())
-                .slackMessage(message)
-                .build());
+        SlackEntity savedEntity = slackRepository.save(
+                SlackEntity.createSlackMessage(
+                        slackRequest.getSlackId(),
+                        message,
+                        slackRequest.getStoreReservationId()
+                )
+        );
 
         return ResSlackMessageDTOApiV1.builder()
                 .slackMessageId(savedEntity.getSlackMessageId())

--- a/store-reservation-service/src/main/java/com/monkey/storereservationservice/infrastructure/config/StoreReservationDataLoader.java
+++ b/store-reservation-service/src/main/java/com/monkey/storereservationservice/infrastructure/config/StoreReservationDataLoader.java
@@ -11,19 +11,19 @@ import org.springframework.context.annotation.Profile;
 import java.util.UUID;
 
 @Configuration
-@Profile("dev") // dev 프로필일 때만 Bean이 등록된다.
+@Profile("dev")
 public class StoreReservationDataLoader {
 
     @Bean
     public CommandLineRunner loadData(StoreReservationRepository storeReservationRepository) {
         return args -> {
-            if (storeReservationRepository.count() == 0) { // 데이터가 없을 경우에만 더미 데이터 추가
-                StoreReservationEntity storeReservationEntity = StoreReservationEntity.builder()
-                        .timeSlotId(UUID.randomUUID())
-                        .userId(1L)
-                        .personCount(2)
-                        .status(StoreReservationStatus.SCHEDULED)
-                        .build();
+            if (storeReservationRepository.count() == 0) {
+                StoreReservationEntity storeReservationEntity = StoreReservationEntity.createStoreReservation(
+                        UUID.randomUUID(),
+                        1L,
+                        2,
+                        StoreReservationStatus.SCHEDULED
+                );
                 storeReservationRepository.save(storeReservationEntity);
             }
         };

--- a/store-reservation-service/src/test/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1Test.java
+++ b/store-reservation-service/src/test/java/com/monkey/storereservationservice/presentation/controller/StoreReservationControllerApiV1Test.java
@@ -55,33 +55,41 @@ public class StoreReservationControllerApiV1Test {
 
     @BeforeEach
     void setUp() {
-        savedId = storeReservationJpaRepository.save(StoreReservationEntity.builder()
-                .userId(1L)
-                .timeSlotId(FIXED_TIMESLOT_ID)
-                .personCount(1)
-                .status(StoreReservationStatus.SCHEDULED)
-                .build()).getStoreReservationId();
+        savedId = storeReservationJpaRepository.save(
+                StoreReservationEntity.createStoreReservation(
+                        FIXED_TIMESLOT_ID,
+                        1L,
+                        1,
+                        StoreReservationStatus.SCHEDULED
+                )
+        ).getStoreReservationId();
 
-        storeReservationJpaRepository.save(StoreReservationEntity.builder()
-                .userId(2L)
-                .timeSlotId(UUID.randomUUID())
-                .personCount(2)
-                .status(StoreReservationStatus.CANCELED)
-                .build());
+        storeReservationJpaRepository.save(
+                StoreReservationEntity.createStoreReservation(
+                        UUID.randomUUID(),
+                        2L,
+                        2,
+                        StoreReservationStatus.CANCELED
+                )
+        );
 
-        storeReservationJpaRepository.save(StoreReservationEntity.builder()
-                .userId(3L)
-                .timeSlotId(UUID.randomUUID())
-                .personCount(3)
-                .status(StoreReservationStatus.VISITED)
-                .build());
+        storeReservationJpaRepository.save(
+                StoreReservationEntity.createStoreReservation(
+                        UUID.randomUUID(),
+                        3L,
+                        3,
+                        StoreReservationStatus.VISITED
+                )
+        );
 
-        storeReservationJpaRepository.save(StoreReservationEntity.builder()
-                .userId(4L)
-                .timeSlotId(UUID.randomUUID())
-                .personCount(4)
-                .status(StoreReservationStatus.NO_SHOW)
-                .build());
+        storeReservationJpaRepository.save(
+                StoreReservationEntity.createStoreReservation(
+                        UUID.randomUUID(),
+                        4L,
+                        4,
+                        StoreReservationStatus.NO_SHOW
+                )
+        );
     }
 
     // 예약 생성


### PR DESCRIPTION
### **📌 작업 내용**

- To-be
    - 스토어예약 도메인과 슬랙 도메인의 엔티티에서 `@Builder` 를 제거하고 정적 팩토리 메서드로 변경함에 따라 해당 엔티티를 사용하는 서비스 및 테스트 코드에서도 생성 방식을 정적 팩토리 방식으로 일괄 수정하였습니다.

### **🧑‍💻 작업 유형**

- [ ]  새로운 기능 추가
- [ ]  버그 수정
- [X]  코드 리팩토링
- [ ]  문서 수정
- [ ]  설정 변경
- [ ]  CI/CD 변경
- [ ]  테스트 추가
- [ ]  테스트 수정
